### PR TITLE
Update deps

### DIFF
--- a/requirements/dev-requirements-py310.txt
+++ b/requirements/dev-requirements-py310.txt
@@ -6,31 +6,31 @@
 #
 alabaster==0.7.12
     # via sphinx
-attrs==21.4.0
+attrs==22.1.0
     # via pytest
-babel==2.9.1
+babel==2.10.3
     # via sphinx
-bleach==4.1.0
+bleach==5.0.1
     # via readme-renderer
-certifi==2021.10.8
+certifi==2022.6.15
     # via requests
-cffi==1.15.0
+cffi==1.15.1
     # via cryptography
-charset-normalizer==2.0.11
+charset-normalizer==2.1.1
     # via requests
-click==8.0.3
+click==8.1.3
     # via
     #   click-log
     #   python-semantic-release
-click-log==0.3.2
+click-log==0.4.0
     # via python-semantic-release
-colorama==0.4.4
+colorama==0.4.5
     # via twine
 commonmark==0.9.1
     # via recommonmark
-cryptography==36.0.1
+cryptography==37.0.4
     # via secretstorage
-distlib==0.3.4
+distlib==0.3.5
     # via virtualenv
 docutils==0.17.1
     # via
@@ -38,48 +38,45 @@ docutils==0.17.1
     #   recommonmark
     #   sphinx
     #   sphinx-rtd-theme
-dotty-dict==1.3.0
+dotty-dict==1.3.1
     # via python-semantic-release
-filelock==3.4.2
+filelock==3.8.0
     # via
     #   tox
     #   virtualenv
 gitdb==4.0.9
     # via gitpython
-gitpython==3.1.26
+gitpython==3.1.27
     # via python-semantic-release
 idna==3.3
     # via requests
-imagesize==1.3.0
+imagesize==1.4.1
     # via sphinx
-importlib-metadata==4.10.1
-    # via
-    #   keyring
-    #   twine
+importlib-metadata==4.12.0
+    # via twine
 iniconfig==1.1.1
     # via pytest
-invoke==1.6.0
+invoke==1.7.1
     # via python-semantic-release
-jeepney==0.7.1
+jeepney==0.8.0
     # via
     #   keyring
     #   secretstorage
-jinja2==3.0.3
+jinja2==3.1.2
     # via sphinx
-keyring==23.5.0
+keyring==23.8.2
     # via twine
-markupsafe==2.0.1
+markupsafe==2.1.1
     # via jinja2
 packaging==21.3
     # via
-    #   bleach
     #   pytest
-    #   setuptools-scm
+    #   python-semantic-release
     #   sphinx
     #   tox
-pkginfo==1.8.2
+pkginfo==1.8.3
     # via twine
-platformdirs==2.4.1
+platformdirs==2.5.2
     # via virtualenv
 pluggy==1.0.0
     # via
@@ -91,25 +88,25 @@ py==1.11.0
     #   tox
 pycparser==2.21
     # via cffi
-pygments==2.11.2
+pygments==2.13.0
     # via
     #   readme-renderer
     #   sphinx
-pyparsing==3.0.7
+pyparsing==3.0.9
     # via packaging
-pytest==6.2.5
+pytest==7.1.2
     # via -r requirements/dev-requirements.in
-python-gitlab==2.10.1
+python-gitlab==3.8.1
     # via python-semantic-release
-python-semantic-release==7.24.0
+python-semantic-release==7.31.4
     # via -r requirements/dev-requirements.in
-pytz==2021.3
+pytz==2022.2.1
     # via babel
-readme-renderer==32.0
+readme-renderer==37.0
     # via twine
 recommonmark==0.7.1
     # via -r requirements/dev-requirements.in
-requests==2.27.1
+requests==2.28.1
     # via
     #   python-gitlab
     #   python-semantic-release
@@ -122,22 +119,19 @@ requests-toolbelt==0.9.1
     #   twine
 rfc3986==2.0.0
     # via twine
-secretstorage==3.3.1
+secretstorage==3.3.3
     # via keyring
 semver==2.13.0
     # via python-semantic-release
-setuptools-scm==6.4.2
-    # via dotty-dict
 six==1.16.0
     # via
     #   bleach
     #   tox
-    #   virtualenv
 smmap==5.0.0
     # via gitdb
 snowballstemmer==2.2.0
     # via sphinx
-sphinx==4.4.0
+sphinx==5.1.1
     # via
     #   -r requirements/dev-requirements.in
     #   recommonmark
@@ -157,29 +151,26 @@ sphinxcontrib-qthelp==1.0.3
 sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
 toml==0.10.2
-    # via
-    #   pytest
-    #   tox
-tomli==2.0.0
-    # via setuptools-scm
-tomlkit==0.7.0
+    # via tox
+tomli==2.0.1
+    # via pytest
+tomlkit==0.11.4
     # via python-semantic-release
-tox==3.24.5
+tox==3.25.1
     # via -r requirements/dev-requirements.in
-tqdm==4.62.3
+tqdm==4.64.0
     # via twine
-twine==3.7.1
+twine==3.8.0
     # via python-semantic-release
-urllib3==1.26.8
-    # via requests
-virtualenv==20.13.0
+urllib3==1.26.12
+    # via
+    #   requests
+    #   twine
+virtualenv==20.16.3
     # via tox
 webencodings==0.5.1
     # via bleach
 wheel==0.37.1
     # via python-semantic-release
-zipp==3.7.0
+zipp==3.8.1
     # via importlib-metadata
-
-# The following packages are considered to be unsafe in a requirements file:
-# setuptools

--- a/requirements/dev-requirements-py37.txt
+++ b/requirements/dev-requirements-py37.txt
@@ -6,31 +6,31 @@
 #
 alabaster==0.7.12
     # via sphinx
-attrs==21.4.0
+attrs==22.1.0
     # via pytest
-babel==2.9.1
+babel==2.10.3
     # via sphinx
-bleach==4.1.0
+bleach==5.0.1
     # via readme-renderer
-certifi==2021.10.8
+certifi==2022.6.15
     # via requests
-cffi==1.15.0
+cffi==1.15.1
     # via cryptography
-charset-normalizer==2.0.11
+charset-normalizer==2.1.1
     # via requests
-click==8.0.3
+click==8.1.3
     # via
     #   click-log
     #   python-semantic-release
-click-log==0.3.2
+click-log==0.4.0
     # via python-semantic-release
-colorama==0.4.4
+colorama==0.4.5
     # via twine
 commonmark==0.9.1
     # via recommonmark
-cryptography==36.0.1
+cryptography==37.0.4
     # via secretstorage
-distlib==0.3.4
+distlib==0.3.5
     # via virtualenv
 docutils==0.17.1
     # via
@@ -38,21 +38,21 @@ docutils==0.17.1
     #   recommonmark
     #   sphinx
     #   sphinx-rtd-theme
-dotty-dict==1.3.0
+dotty-dict==1.3.1
     # via python-semantic-release
-filelock==3.4.2
+filelock==3.8.0
     # via
     #   tox
     #   virtualenv
 gitdb==4.0.9
     # via gitpython
-gitpython==3.1.26
+gitpython==3.1.27
     # via python-semantic-release
 idna==3.3
     # via requests
-imagesize==1.3.0
+imagesize==1.4.1
     # via sphinx
-importlib-metadata==4.10.1
+importlib-metadata==4.12.0
     # via
     #   click
     #   keyring
@@ -64,28 +64,27 @@ importlib-metadata==4.10.1
     #   virtualenv
 iniconfig==1.1.1
     # via pytest
-invoke==1.6.0
+invoke==1.7.1
     # via python-semantic-release
-jeepney==0.7.1
+jeepney==0.8.0
     # via
     #   keyring
     #   secretstorage
-jinja2==3.0.3
+jinja2==3.1.2
     # via sphinx
-keyring==23.5.0
+keyring==23.8.2
     # via twine
-markupsafe==2.0.1
+markupsafe==2.1.1
     # via jinja2
 packaging==21.3
     # via
-    #   bleach
     #   pytest
-    #   setuptools-scm
+    #   python-semantic-release
     #   sphinx
     #   tox
-pkginfo==1.8.2
+pkginfo==1.8.3
     # via twine
-platformdirs==2.4.1
+platformdirs==2.5.2
     # via virtualenv
 pluggy==1.0.0
     # via
@@ -97,25 +96,25 @@ py==1.11.0
     #   tox
 pycparser==2.21
     # via cffi
-pygments==2.11.2
+pygments==2.13.0
     # via
     #   readme-renderer
     #   sphinx
-pyparsing==3.0.7
+pyparsing==3.0.9
     # via packaging
-pytest==6.2.5
+pytest==7.1.2
     # via -r requirements/dev-requirements.in
-python-gitlab==2.10.1
+python-gitlab==3.8.1
     # via python-semantic-release
-python-semantic-release==7.24.0
+python-semantic-release==7.31.4
     # via -r requirements/dev-requirements.in
-pytz==2021.3
+pytz==2022.2.1
     # via babel
-readme-renderer==32.0
+readme-renderer==37.0
     # via twine
 recommonmark==0.7.1
     # via -r requirements/dev-requirements.in
-requests==2.27.1
+requests==2.28.1
     # via
     #   python-gitlab
     #   python-semantic-release
@@ -128,22 +127,19 @@ requests-toolbelt==0.9.1
     #   twine
 rfc3986==2.0.0
     # via twine
-secretstorage==3.3.1
+secretstorage==3.3.3
     # via keyring
 semver==2.13.0
     # via python-semantic-release
-setuptools-scm==6.4.2
-    # via dotty-dict
 six==1.16.0
     # via
     #   bleach
     #   tox
-    #   virtualenv
 smmap==5.0.0
     # via gitdb
 snowballstemmer==2.2.0
     # via sphinx
-sphinx==4.4.0
+sphinx==5.1.1
     # via
     #   -r requirements/dev-requirements.in
     #   recommonmark
@@ -163,33 +159,30 @@ sphinxcontrib-qthelp==1.0.3
 sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
 toml==0.10.2
-    # via
-    #   pytest
-    #   tox
-tomli==2.0.0
-    # via setuptools-scm
-tomlkit==0.7.0
+    # via tox
+tomli==2.0.1
+    # via pytest
+tomlkit==0.11.4
     # via python-semantic-release
-tox==3.24.5
+tox==3.25.1
     # via -r requirements/dev-requirements.in
-tqdm==4.62.3
+tqdm==4.64.0
     # via twine
-twine==3.7.1
+twine==3.8.0
     # via python-semantic-release
-typing-extensions==4.0.1
+typing-extensions==4.3.0
     # via
     #   gitpython
     #   importlib-metadata
-urllib3==1.26.8
-    # via requests
-virtualenv==20.13.0
+urllib3==1.26.12
+    # via
+    #   requests
+    #   twine
+virtualenv==20.16.3
     # via tox
 webencodings==0.5.1
     # via bleach
 wheel==0.37.1
     # via python-semantic-release
-zipp==3.7.0
+zipp==3.8.1
     # via importlib-metadata
-
-# The following packages are considered to be unsafe in a requirements file:
-# setuptools

--- a/requirements/dev-requirements-py38.txt
+++ b/requirements/dev-requirements-py38.txt
@@ -6,31 +6,31 @@
 #
 alabaster==0.7.12
     # via sphinx
-attrs==21.4.0
+attrs==22.1.0
     # via pytest
-babel==2.9.1
+babel==2.10.3
     # via sphinx
-bleach==4.1.0
+bleach==5.0.1
     # via readme-renderer
-certifi==2021.10.8
+certifi==2022.6.15
     # via requests
-cffi==1.15.0
+cffi==1.15.1
     # via cryptography
-charset-normalizer==2.0.11
+charset-normalizer==2.1.1
     # via requests
-click==8.0.3
+click==8.1.3
     # via
     #   click-log
     #   python-semantic-release
-click-log==0.3.2
+click-log==0.4.0
     # via python-semantic-release
-colorama==0.4.4
+colorama==0.4.5
     # via twine
 commonmark==0.9.1
     # via recommonmark
-cryptography==36.0.1
+cryptography==37.0.4
     # via secretstorage
-distlib==0.3.4
+distlib==0.3.5
     # via virtualenv
 docutils==0.17.1
     # via
@@ -38,49 +38,48 @@ docutils==0.17.1
     #   recommonmark
     #   sphinx
     #   sphinx-rtd-theme
-dotty-dict==1.3.0
+dotty-dict==1.3.1
     # via python-semantic-release
-filelock==3.4.2
+filelock==3.8.0
     # via
     #   tox
     #   virtualenv
 gitdb==4.0.9
     # via gitpython
-gitpython==3.1.26
+gitpython==3.1.27
     # via python-semantic-release
 idna==3.3
     # via requests
-imagesize==1.3.0
+imagesize==1.4.1
     # via sphinx
-importlib-metadata==4.10.1
+importlib-metadata==4.12.0
     # via
     #   keyring
     #   sphinx
     #   twine
 iniconfig==1.1.1
     # via pytest
-invoke==1.6.0
+invoke==1.7.1
     # via python-semantic-release
-jeepney==0.7.1
+jeepney==0.8.0
     # via
     #   keyring
     #   secretstorage
-jinja2==3.0.3
+jinja2==3.1.2
     # via sphinx
-keyring==23.5.0
+keyring==23.8.2
     # via twine
-markupsafe==2.0.1
+markupsafe==2.1.1
     # via jinja2
 packaging==21.3
     # via
-    #   bleach
     #   pytest
-    #   setuptools-scm
+    #   python-semantic-release
     #   sphinx
     #   tox
-pkginfo==1.8.2
+pkginfo==1.8.3
     # via twine
-platformdirs==2.4.1
+platformdirs==2.5.2
     # via virtualenv
 pluggy==1.0.0
     # via
@@ -92,25 +91,25 @@ py==1.11.0
     #   tox
 pycparser==2.21
     # via cffi
-pygments==2.11.2
+pygments==2.13.0
     # via
     #   readme-renderer
     #   sphinx
-pyparsing==3.0.7
+pyparsing==3.0.9
     # via packaging
-pytest==6.2.5
+pytest==7.1.2
     # via -r requirements/dev-requirements.in
-python-gitlab==2.10.1
+python-gitlab==3.8.1
     # via python-semantic-release
-python-semantic-release==7.24.0
+python-semantic-release==7.31.4
     # via -r requirements/dev-requirements.in
-pytz==2021.3
+pytz==2022.2.1
     # via babel
-readme-renderer==32.0
+readme-renderer==37.0
     # via twine
 recommonmark==0.7.1
     # via -r requirements/dev-requirements.in
-requests==2.27.1
+requests==2.28.1
     # via
     #   python-gitlab
     #   python-semantic-release
@@ -123,22 +122,19 @@ requests-toolbelt==0.9.1
     #   twine
 rfc3986==2.0.0
     # via twine
-secretstorage==3.3.1
+secretstorage==3.3.3
     # via keyring
 semver==2.13.0
     # via python-semantic-release
-setuptools-scm==6.4.2
-    # via dotty-dict
 six==1.16.0
     # via
     #   bleach
     #   tox
-    #   virtualenv
 smmap==5.0.0
     # via gitdb
 snowballstemmer==2.2.0
     # via sphinx
-sphinx==4.4.0
+sphinx==5.1.1
     # via
     #   -r requirements/dev-requirements.in
     #   recommonmark
@@ -158,29 +154,26 @@ sphinxcontrib-qthelp==1.0.3
 sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
 toml==0.10.2
-    # via
-    #   pytest
-    #   tox
-tomli==2.0.0
-    # via setuptools-scm
-tomlkit==0.7.0
+    # via tox
+tomli==2.0.1
+    # via pytest
+tomlkit==0.11.4
     # via python-semantic-release
-tox==3.24.5
+tox==3.25.1
     # via -r requirements/dev-requirements.in
-tqdm==4.62.3
+tqdm==4.64.0
     # via twine
-twine==3.7.1
+twine==3.8.0
     # via python-semantic-release
-urllib3==1.26.8
-    # via requests
-virtualenv==20.13.0
+urllib3==1.26.12
+    # via
+    #   requests
+    #   twine
+virtualenv==20.16.3
     # via tox
 webencodings==0.5.1
     # via bleach
 wheel==0.37.1
     # via python-semantic-release
-zipp==3.7.0
+zipp==3.8.1
     # via importlib-metadata
-
-# The following packages are considered to be unsafe in a requirements file:
-# setuptools

--- a/requirements/dev-requirements-py39.txt
+++ b/requirements/dev-requirements-py39.txt
@@ -6,31 +6,31 @@
 #
 alabaster==0.7.12
     # via sphinx
-attrs==21.4.0
+attrs==22.1.0
     # via pytest
-babel==2.9.1
+babel==2.10.3
     # via sphinx
-bleach==4.1.0
+bleach==5.0.1
     # via readme-renderer
-certifi==2021.10.8
+certifi==2022.6.15
     # via requests
-cffi==1.15.0
+cffi==1.15.1
     # via cryptography
-charset-normalizer==2.0.11
+charset-normalizer==2.1.1
     # via requests
-click==8.0.3
+click==8.1.3
     # via
     #   click-log
     #   python-semantic-release
-click-log==0.3.2
+click-log==0.4.0
     # via python-semantic-release
-colorama==0.4.4
+colorama==0.4.5
     # via twine
 commonmark==0.9.1
     # via recommonmark
-cryptography==36.0.1
+cryptography==37.0.4
     # via secretstorage
-distlib==0.3.4
+distlib==0.3.5
     # via virtualenv
 docutils==0.17.1
     # via
@@ -38,49 +38,48 @@ docutils==0.17.1
     #   recommonmark
     #   sphinx
     #   sphinx-rtd-theme
-dotty-dict==1.3.0
+dotty-dict==1.3.1
     # via python-semantic-release
-filelock==3.4.2
+filelock==3.8.0
     # via
     #   tox
     #   virtualenv
 gitdb==4.0.9
     # via gitpython
-gitpython==3.1.26
+gitpython==3.1.27
     # via python-semantic-release
 idna==3.3
     # via requests
-imagesize==1.3.0
+imagesize==1.4.1
     # via sphinx
-importlib-metadata==4.10.1
+importlib-metadata==4.12.0
     # via
     #   keyring
     #   sphinx
     #   twine
 iniconfig==1.1.1
     # via pytest
-invoke==1.6.0
+invoke==1.7.1
     # via python-semantic-release
-jeepney==0.7.1
+jeepney==0.8.0
     # via
     #   keyring
     #   secretstorage
-jinja2==3.0.3
+jinja2==3.1.2
     # via sphinx
-keyring==23.5.0
+keyring==23.8.2
     # via twine
-markupsafe==2.0.1
+markupsafe==2.1.1
     # via jinja2
 packaging==21.3
     # via
-    #   bleach
     #   pytest
-    #   setuptools-scm
+    #   python-semantic-release
     #   sphinx
     #   tox
-pkginfo==1.8.2
+pkginfo==1.8.3
     # via twine
-platformdirs==2.4.1
+platformdirs==2.5.2
     # via virtualenv
 pluggy==1.0.0
     # via
@@ -92,25 +91,25 @@ py==1.11.0
     #   tox
 pycparser==2.21
     # via cffi
-pygments==2.11.2
+pygments==2.13.0
     # via
     #   readme-renderer
     #   sphinx
-pyparsing==3.0.7
+pyparsing==3.0.9
     # via packaging
-pytest==6.2.5
+pytest==7.1.2
     # via -r requirements/dev-requirements.in
-python-gitlab==2.10.1
+python-gitlab==3.8.1
     # via python-semantic-release
-python-semantic-release==7.24.0
+python-semantic-release==7.31.4
     # via -r requirements/dev-requirements.in
-pytz==2021.3
+pytz==2022.2.1
     # via babel
-readme-renderer==32.0
+readme-renderer==37.0
     # via twine
 recommonmark==0.7.1
     # via -r requirements/dev-requirements.in
-requests==2.27.1
+requests==2.28.1
     # via
     #   python-gitlab
     #   python-semantic-release
@@ -123,22 +122,19 @@ requests-toolbelt==0.9.1
     #   twine
 rfc3986==2.0.0
     # via twine
-secretstorage==3.3.1
+secretstorage==3.3.3
     # via keyring
 semver==2.13.0
     # via python-semantic-release
-setuptools-scm==6.4.2
-    # via dotty-dict
 six==1.16.0
     # via
     #   bleach
     #   tox
-    #   virtualenv
 smmap==5.0.0
     # via gitdb
 snowballstemmer==2.2.0
     # via sphinx
-sphinx==4.4.0
+sphinx==5.1.1
     # via
     #   -r requirements/dev-requirements.in
     #   recommonmark
@@ -158,29 +154,26 @@ sphinxcontrib-qthelp==1.0.3
 sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
 toml==0.10.2
-    # via
-    #   pytest
-    #   tox
-tomli==2.0.0
-    # via setuptools-scm
-tomlkit==0.7.0
+    # via tox
+tomli==2.0.1
+    # via pytest
+tomlkit==0.11.4
     # via python-semantic-release
-tox==3.24.5
+tox==3.25.1
     # via -r requirements/dev-requirements.in
-tqdm==4.62.3
+tqdm==4.64.0
     # via twine
-twine==3.7.1
+twine==3.8.0
     # via python-semantic-release
-urllib3==1.26.8
-    # via requests
-virtualenv==20.13.0
+urllib3==1.26.12
+    # via
+    #   requests
+    #   twine
+virtualenv==20.16.3
     # via tox
 webencodings==0.5.1
     # via bleach
 wheel==0.37.1
     # via python-semantic-release
-zipp==3.7.0
+zipp==3.8.1
     # via importlib-metadata
-
-# The following packages are considered to be unsafe in a requirements file:
-# setuptools


### PR DESCRIPTION
This PR provides recompiled deps for all outdated       package versions. It was opened after the committed deps       were successfully compiled and all tests passed with the       new versions. It should be merged as soon as possible to       avoid any security issues due to outdated dependencies.