### PR TITLE
Update deps

### DIFF
--- a/requirements/dev-requirements-py310.txt
+++ b/requirements/dev-requirements-py310.txt
@@ -30,7 +30,7 @@ commonmark==0.9.1
     # via recommonmark
 cryptography==37.0.4
     # via secretstorage
-distlib==0.3.5
+distlib==0.3.6
     # via virtualenv
 docutils==0.17.1
     # via
@@ -96,7 +96,7 @@ pyparsing==3.0.9
     # via packaging
 pytest==7.1.2
     # via -r requirements/dev-requirements.in
-python-gitlab==3.8.1
+python-gitlab==3.9.0
     # via python-semantic-release
 python-semantic-release==7.31.4
     # via -r requirements/dev-requirements.in
@@ -166,7 +166,7 @@ urllib3==1.26.12
     # via
     #   requests
     #   twine
-virtualenv==20.16.3
+virtualenv==20.16.4
     # via tox
 webencodings==0.5.1
     # via bleach

--- a/requirements/dev-requirements-py37.txt
+++ b/requirements/dev-requirements-py37.txt
@@ -30,7 +30,7 @@ commonmark==0.9.1
     # via recommonmark
 cryptography==37.0.4
     # via secretstorage
-distlib==0.3.5
+distlib==0.3.6
     # via virtualenv
 docutils==0.17.1
     # via
@@ -104,7 +104,7 @@ pyparsing==3.0.9
     # via packaging
 pytest==7.1.2
     # via -r requirements/dev-requirements.in
-python-gitlab==3.8.1
+python-gitlab==3.9.0
     # via python-semantic-release
 python-semantic-release==7.31.4
     # via -r requirements/dev-requirements.in
@@ -178,7 +178,7 @@ urllib3==1.26.12
     # via
     #   requests
     #   twine
-virtualenv==20.16.3
+virtualenv==20.16.4
     # via tox
 webencodings==0.5.1
     # via bleach

--- a/requirements/dev-requirements-py38.txt
+++ b/requirements/dev-requirements-py38.txt
@@ -30,7 +30,7 @@ commonmark==0.9.1
     # via recommonmark
 cryptography==37.0.4
     # via secretstorage
-distlib==0.3.5
+distlib==0.3.6
     # via virtualenv
 docutils==0.17.1
     # via
@@ -99,7 +99,7 @@ pyparsing==3.0.9
     # via packaging
 pytest==7.1.2
     # via -r requirements/dev-requirements.in
-python-gitlab==3.8.1
+python-gitlab==3.9.0
     # via python-semantic-release
 python-semantic-release==7.31.4
     # via -r requirements/dev-requirements.in
@@ -169,7 +169,7 @@ urllib3==1.26.12
     # via
     #   requests
     #   twine
-virtualenv==20.16.3
+virtualenv==20.16.4
     # via tox
 webencodings==0.5.1
     # via bleach

--- a/requirements/dev-requirements-py39.txt
+++ b/requirements/dev-requirements-py39.txt
@@ -30,7 +30,7 @@ commonmark==0.9.1
     # via recommonmark
 cryptography==37.0.4
     # via secretstorage
-distlib==0.3.5
+distlib==0.3.6
     # via virtualenv
 docutils==0.17.1
     # via
@@ -99,7 +99,7 @@ pyparsing==3.0.9
     # via packaging
 pytest==7.1.2
     # via -r requirements/dev-requirements.in
-python-gitlab==3.8.1
+python-gitlab==3.9.0
     # via python-semantic-release
 python-semantic-release==7.31.4
     # via -r requirements/dev-requirements.in
@@ -169,7 +169,7 @@ urllib3==1.26.12
     # via
     #   requests
     #   twine
-virtualenv==20.16.3
+virtualenv==20.16.4
     # via tox
 webencodings==0.5.1
     # via bleach


### PR DESCRIPTION
This PR provides recompiled deps for all outdated       package versions. It was opened after the committed deps       were successfully compiled and all tests passed with the       new versions. It should be merged as soon as possible to       avoid any security issues due to outdated dependencies.