### PR TITLE
Update deps

### DIFF
--- a/requirements/dev-requirements-py310.txt
+++ b/requirements/dev-requirements-py310.txt
@@ -12,7 +12,7 @@ babel==2.10.3
     # via sphinx
 bleach==5.0.1
     # via readme-renderer
-certifi==2022.6.15
+certifi==2022.9.14
     # via requests
 cffi==1.15.1
     # via cryptography
@@ -28,7 +28,7 @@ colorama==0.4.5
     # via twine
 commonmark==0.9.1
     # via recommonmark
-cryptography==37.0.4
+cryptography==38.0.1
     # via secretstorage
 distlib==0.3.6
     # via virtualenv
@@ -48,7 +48,7 @@ gitdb==4.0.9
     # via gitpython
 gitpython==3.1.27
     # via python-semantic-release
-idna==3.3
+idna==3.4
     # via requests
 imagesize==1.4.1
     # via sphinx
@@ -58,16 +58,20 @@ iniconfig==1.1.1
     # via pytest
 invoke==1.7.1
     # via python-semantic-release
+jaraco-classes==3.2.2
+    # via keyring
 jeepney==0.8.0
     # via
     #   keyring
     #   secretstorage
 jinja2==3.1.2
     # via sphinx
-keyring==23.8.2
+keyring==23.9.1
     # via twine
 markupsafe==2.1.1
     # via jinja2
+more-itertools==8.14.0
+    # via jaraco-classes
 packaging==21.3
     # via
     #   pytest
@@ -94,7 +98,7 @@ pygments==2.13.0
     #   sphinx
 pyparsing==3.0.9
     # via packaging
-pytest==7.1.2
+pytest==7.1.3
     # via -r requirements/dev-requirements.in
 python-gitlab==3.9.0
     # via python-semantic-release
@@ -102,7 +106,7 @@ python-semantic-release==7.31.4
     # via -r requirements/dev-requirements.in
 pytz==2022.2.1
     # via babel
-readme-renderer==37.0
+readme-renderer==37.1
     # via twine
 recommonmark==0.7.1
     # via -r requirements/dev-requirements.in
@@ -150,15 +154,15 @@ sphinxcontrib-qthelp==1.0.3
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
-toml==0.10.2
-    # via tox
 tomli==2.0.1
-    # via pytest
+    # via
+    #   pytest
+    #   tox
 tomlkit==0.11.4
     # via python-semantic-release
-tox==3.25.1
+tox==3.26.0
     # via -r requirements/dev-requirements.in
-tqdm==4.64.0
+tqdm==4.64.1
     # via twine
 twine==3.8.0
     # via python-semantic-release
@@ -166,7 +170,7 @@ urllib3==1.26.12
     # via
     #   requests
     #   twine
-virtualenv==20.16.4
+virtualenv==20.16.5
     # via tox
 webencodings==0.5.1
     # via bleach

--- a/requirements/dev-requirements-py37.txt
+++ b/requirements/dev-requirements-py37.txt
@@ -12,7 +12,7 @@ babel==2.10.3
     # via sphinx
 bleach==5.0.1
     # via readme-renderer
-certifi==2022.6.15
+certifi==2022.9.14
     # via requests
 cffi==1.15.1
     # via cryptography
@@ -28,7 +28,7 @@ colorama==0.4.5
     # via twine
 commonmark==0.9.1
     # via recommonmark
-cryptography==37.0.4
+cryptography==38.0.1
     # via secretstorage
 distlib==0.3.6
     # via virtualenv
@@ -48,7 +48,7 @@ gitdb==4.0.9
     # via gitpython
 gitpython==3.1.27
     # via python-semantic-release
-idna==3.3
+idna==3.4
     # via requests
 imagesize==1.4.1
     # via sphinx
@@ -66,16 +66,20 @@ iniconfig==1.1.1
     # via pytest
 invoke==1.7.1
     # via python-semantic-release
+jaraco-classes==3.2.2
+    # via keyring
 jeepney==0.8.0
     # via
     #   keyring
     #   secretstorage
 jinja2==3.1.2
     # via sphinx
-keyring==23.8.2
+keyring==23.9.1
     # via twine
 markupsafe==2.1.1
     # via jinja2
+more-itertools==8.14.0
+    # via jaraco-classes
 packaging==21.3
     # via
     #   pytest
@@ -102,7 +106,7 @@ pygments==2.13.0
     #   sphinx
 pyparsing==3.0.9
     # via packaging
-pytest==7.1.2
+pytest==7.1.3
     # via -r requirements/dev-requirements.in
 python-gitlab==3.9.0
     # via python-semantic-release
@@ -110,7 +114,7 @@ python-semantic-release==7.31.4
     # via -r requirements/dev-requirements.in
 pytz==2022.2.1
     # via babel
-readme-renderer==37.0
+readme-renderer==37.1
     # via twine
 recommonmark==0.7.1
     # via -r requirements/dev-requirements.in
@@ -158,15 +162,15 @@ sphinxcontrib-qthelp==1.0.3
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
-toml==0.10.2
-    # via tox
 tomli==2.0.1
-    # via pytest
+    # via
+    #   pytest
+    #   tox
 tomlkit==0.11.4
     # via python-semantic-release
-tox==3.25.1
+tox==3.26.0
     # via -r requirements/dev-requirements.in
-tqdm==4.64.0
+tqdm==4.64.1
     # via twine
 twine==3.8.0
     # via python-semantic-release
@@ -178,7 +182,7 @@ urllib3==1.26.12
     # via
     #   requests
     #   twine
-virtualenv==20.16.4
+virtualenv==20.16.5
     # via tox
 webencodings==0.5.1
     # via bleach

--- a/requirements/dev-requirements-py38.txt
+++ b/requirements/dev-requirements-py38.txt
@@ -12,7 +12,7 @@ babel==2.10.3
     # via sphinx
 bleach==5.0.1
     # via readme-renderer
-certifi==2022.6.15
+certifi==2022.9.14
     # via requests
 cffi==1.15.1
     # via cryptography
@@ -28,7 +28,7 @@ colorama==0.4.5
     # via twine
 commonmark==0.9.1
     # via recommonmark
-cryptography==37.0.4
+cryptography==38.0.1
     # via secretstorage
 distlib==0.3.6
     # via virtualenv
@@ -48,7 +48,7 @@ gitdb==4.0.9
     # via gitpython
 gitpython==3.1.27
     # via python-semantic-release
-idna==3.3
+idna==3.4
     # via requests
 imagesize==1.4.1
     # via sphinx
@@ -61,16 +61,20 @@ iniconfig==1.1.1
     # via pytest
 invoke==1.7.1
     # via python-semantic-release
+jaraco-classes==3.2.2
+    # via keyring
 jeepney==0.8.0
     # via
     #   keyring
     #   secretstorage
 jinja2==3.1.2
     # via sphinx
-keyring==23.8.2
+keyring==23.9.1
     # via twine
 markupsafe==2.1.1
     # via jinja2
+more-itertools==8.14.0
+    # via jaraco-classes
 packaging==21.3
     # via
     #   pytest
@@ -97,7 +101,7 @@ pygments==2.13.0
     #   sphinx
 pyparsing==3.0.9
     # via packaging
-pytest==7.1.2
+pytest==7.1.3
     # via -r requirements/dev-requirements.in
 python-gitlab==3.9.0
     # via python-semantic-release
@@ -105,7 +109,7 @@ python-semantic-release==7.31.4
     # via -r requirements/dev-requirements.in
 pytz==2022.2.1
     # via babel
-readme-renderer==37.0
+readme-renderer==37.1
     # via twine
 recommonmark==0.7.1
     # via -r requirements/dev-requirements.in
@@ -153,15 +157,15 @@ sphinxcontrib-qthelp==1.0.3
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
-toml==0.10.2
-    # via tox
 tomli==2.0.1
-    # via pytest
+    # via
+    #   pytest
+    #   tox
 tomlkit==0.11.4
     # via python-semantic-release
-tox==3.25.1
+tox==3.26.0
     # via -r requirements/dev-requirements.in
-tqdm==4.64.0
+tqdm==4.64.1
     # via twine
 twine==3.8.0
     # via python-semantic-release
@@ -169,7 +173,7 @@ urllib3==1.26.12
     # via
     #   requests
     #   twine
-virtualenv==20.16.4
+virtualenv==20.16.5
     # via tox
 webencodings==0.5.1
     # via bleach

--- a/requirements/dev-requirements-py39.txt
+++ b/requirements/dev-requirements-py39.txt
@@ -12,7 +12,7 @@ babel==2.10.3
     # via sphinx
 bleach==5.0.1
     # via readme-renderer
-certifi==2022.6.15
+certifi==2022.9.14
     # via requests
 cffi==1.15.1
     # via cryptography
@@ -28,7 +28,7 @@ colorama==0.4.5
     # via twine
 commonmark==0.9.1
     # via recommonmark
-cryptography==37.0.4
+cryptography==38.0.1
     # via secretstorage
 distlib==0.3.6
     # via virtualenv
@@ -48,7 +48,7 @@ gitdb==4.0.9
     # via gitpython
 gitpython==3.1.27
     # via python-semantic-release
-idna==3.3
+idna==3.4
     # via requests
 imagesize==1.4.1
     # via sphinx
@@ -61,16 +61,20 @@ iniconfig==1.1.1
     # via pytest
 invoke==1.7.1
     # via python-semantic-release
+jaraco-classes==3.2.2
+    # via keyring
 jeepney==0.8.0
     # via
     #   keyring
     #   secretstorage
 jinja2==3.1.2
     # via sphinx
-keyring==23.8.2
+keyring==23.9.1
     # via twine
 markupsafe==2.1.1
     # via jinja2
+more-itertools==8.14.0
+    # via jaraco-classes
 packaging==21.3
     # via
     #   pytest
@@ -97,7 +101,7 @@ pygments==2.13.0
     #   sphinx
 pyparsing==3.0.9
     # via packaging
-pytest==7.1.2
+pytest==7.1.3
     # via -r requirements/dev-requirements.in
 python-gitlab==3.9.0
     # via python-semantic-release
@@ -105,7 +109,7 @@ python-semantic-release==7.31.4
     # via -r requirements/dev-requirements.in
 pytz==2022.2.1
     # via babel
-readme-renderer==37.0
+readme-renderer==37.1
     # via twine
 recommonmark==0.7.1
     # via -r requirements/dev-requirements.in
@@ -153,15 +157,15 @@ sphinxcontrib-qthelp==1.0.3
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
-toml==0.10.2
-    # via tox
 tomli==2.0.1
-    # via pytest
+    # via
+    #   pytest
+    #   tox
 tomlkit==0.11.4
     # via python-semantic-release
-tox==3.25.1
+tox==3.26.0
     # via -r requirements/dev-requirements.in
-tqdm==4.64.0
+tqdm==4.64.1
     # via twine
 twine==3.8.0
     # via python-semantic-release
@@ -169,7 +173,7 @@ urllib3==1.26.12
     # via
     #   requests
     #   twine
-virtualenv==20.16.4
+virtualenv==20.16.5
     # via tox
 webencodings==0.5.1
     # via bleach


### PR DESCRIPTION
This PR provides recompiled deps for all outdated       package versions. It was opened after the committed deps       were successfully compiled and all tests passed with the       new versions. It should be merged as soon as possible to       avoid any security issues due to outdated dependencies.