### PR TITLE
Update deps

### DIFF
--- a/requirements/dev-requirements-py310.txt
+++ b/requirements/dev-requirements-py310.txt
@@ -12,7 +12,7 @@ babel==2.10.3
     # via sphinx
 bleach==5.0.1
     # via readme-renderer
-certifi==2022.9.14
+certifi==2022.9.24
     # via requests
 cffi==1.15.1
     # via cryptography
@@ -56,9 +56,9 @@ importlib-metadata==4.12.0
     # via twine
 iniconfig==1.1.1
     # via pytest
-invoke==1.7.1
+invoke==1.7.3
     # via python-semantic-release
-jaraco-classes==3.2.2
+jaraco-classes==3.2.3
     # via keyring
 jeepney==0.8.0
     # via
@@ -66,7 +66,7 @@ jeepney==0.8.0
     #   secretstorage
 jinja2==3.1.2
     # via sphinx
-keyring==23.9.1
+keyring==23.9.3
     # via twine
 markupsafe==2.1.1
     # via jinja2
@@ -100,13 +100,13 @@ pyparsing==3.0.9
     # via packaging
 pytest==7.1.3
     # via -r requirements/dev-requirements.in
-python-gitlab==3.9.0
+python-gitlab==3.10.0
     # via python-semantic-release
-python-semantic-release==7.31.4
+python-semantic-release==7.32.0
     # via -r requirements/dev-requirements.in
 pytz==2022.2.1
     # via babel
-readme-renderer==37.1
+readme-renderer==37.2
     # via twine
 recommonmark==0.7.1
     # via -r requirements/dev-requirements.in
@@ -135,7 +135,7 @@ smmap==5.0.0
     # via gitdb
 snowballstemmer==2.2.0
     # via sphinx
-sphinx==5.1.1
+sphinx==5.2.3
     # via
     #   -r requirements/dev-requirements.in
     #   recommonmark
@@ -158,7 +158,7 @@ tomli==2.0.1
     # via
     #   pytest
     #   tox
-tomlkit==0.11.4
+tomlkit==0.11.5
     # via python-semantic-release
 tox==3.26.0
     # via -r requirements/dev-requirements.in

--- a/requirements/dev-requirements-py37.txt
+++ b/requirements/dev-requirements-py37.txt
@@ -12,7 +12,7 @@ babel==2.10.3
     # via sphinx
 bleach==5.0.1
     # via readme-renderer
-certifi==2022.9.14
+certifi==2022.9.24
     # via requests
 cffi==1.15.1
     # via cryptography
@@ -64,9 +64,9 @@ importlib-metadata==4.12.0
     #   virtualenv
 iniconfig==1.1.1
     # via pytest
-invoke==1.7.1
+invoke==1.7.3
     # via python-semantic-release
-jaraco-classes==3.2.2
+jaraco-classes==3.2.3
     # via keyring
 jeepney==0.8.0
     # via
@@ -74,7 +74,7 @@ jeepney==0.8.0
     #   secretstorage
 jinja2==3.1.2
     # via sphinx
-keyring==23.9.1
+keyring==23.9.3
     # via twine
 markupsafe==2.1.1
     # via jinja2
@@ -108,13 +108,13 @@ pyparsing==3.0.9
     # via packaging
 pytest==7.1.3
     # via -r requirements/dev-requirements.in
-python-gitlab==3.9.0
+python-gitlab==3.10.0
     # via python-semantic-release
-python-semantic-release==7.31.4
+python-semantic-release==7.32.0
     # via -r requirements/dev-requirements.in
 pytz==2022.2.1
     # via babel
-readme-renderer==37.1
+readme-renderer==37.2
     # via twine
 recommonmark==0.7.1
     # via -r requirements/dev-requirements.in
@@ -143,7 +143,7 @@ smmap==5.0.0
     # via gitdb
 snowballstemmer==2.2.0
     # via sphinx
-sphinx==5.1.1
+sphinx==5.2.3
     # via
     #   -r requirements/dev-requirements.in
     #   recommonmark
@@ -166,7 +166,7 @@ tomli==2.0.1
     # via
     #   pytest
     #   tox
-tomlkit==0.11.4
+tomlkit==0.11.5
     # via python-semantic-release
 tox==3.26.0
     # via -r requirements/dev-requirements.in

--- a/requirements/dev-requirements-py38.txt
+++ b/requirements/dev-requirements-py38.txt
@@ -12,7 +12,7 @@ babel==2.10.3
     # via sphinx
 bleach==5.0.1
     # via readme-renderer
-certifi==2022.9.14
+certifi==2022.9.24
     # via requests
 cffi==1.15.1
     # via cryptography
@@ -59,9 +59,9 @@ importlib-metadata==4.12.0
     #   twine
 iniconfig==1.1.1
     # via pytest
-invoke==1.7.1
+invoke==1.7.3
     # via python-semantic-release
-jaraco-classes==3.2.2
+jaraco-classes==3.2.3
     # via keyring
 jeepney==0.8.0
     # via
@@ -69,7 +69,7 @@ jeepney==0.8.0
     #   secretstorage
 jinja2==3.1.2
     # via sphinx
-keyring==23.9.1
+keyring==23.9.3
     # via twine
 markupsafe==2.1.1
     # via jinja2
@@ -103,13 +103,13 @@ pyparsing==3.0.9
     # via packaging
 pytest==7.1.3
     # via -r requirements/dev-requirements.in
-python-gitlab==3.9.0
+python-gitlab==3.10.0
     # via python-semantic-release
-python-semantic-release==7.31.4
+python-semantic-release==7.32.0
     # via -r requirements/dev-requirements.in
 pytz==2022.2.1
     # via babel
-readme-renderer==37.1
+readme-renderer==37.2
     # via twine
 recommonmark==0.7.1
     # via -r requirements/dev-requirements.in
@@ -138,7 +138,7 @@ smmap==5.0.0
     # via gitdb
 snowballstemmer==2.2.0
     # via sphinx
-sphinx==5.1.1
+sphinx==5.2.3
     # via
     #   -r requirements/dev-requirements.in
     #   recommonmark
@@ -161,7 +161,7 @@ tomli==2.0.1
     # via
     #   pytest
     #   tox
-tomlkit==0.11.4
+tomlkit==0.11.5
     # via python-semantic-release
 tox==3.26.0
     # via -r requirements/dev-requirements.in

--- a/requirements/dev-requirements-py39.txt
+++ b/requirements/dev-requirements-py39.txt
@@ -12,7 +12,7 @@ babel==2.10.3
     # via sphinx
 bleach==5.0.1
     # via readme-renderer
-certifi==2022.9.14
+certifi==2022.9.24
     # via requests
 cffi==1.15.1
     # via cryptography
@@ -59,9 +59,9 @@ importlib-metadata==4.12.0
     #   twine
 iniconfig==1.1.1
     # via pytest
-invoke==1.7.1
+invoke==1.7.3
     # via python-semantic-release
-jaraco-classes==3.2.2
+jaraco-classes==3.2.3
     # via keyring
 jeepney==0.8.0
     # via
@@ -69,7 +69,7 @@ jeepney==0.8.0
     #   secretstorage
 jinja2==3.1.2
     # via sphinx
-keyring==23.9.1
+keyring==23.9.3
     # via twine
 markupsafe==2.1.1
     # via jinja2
@@ -103,13 +103,13 @@ pyparsing==3.0.9
     # via packaging
 pytest==7.1.3
     # via -r requirements/dev-requirements.in
-python-gitlab==3.9.0
+python-gitlab==3.10.0
     # via python-semantic-release
-python-semantic-release==7.31.4
+python-semantic-release==7.32.0
     # via -r requirements/dev-requirements.in
 pytz==2022.2.1
     # via babel
-readme-renderer==37.1
+readme-renderer==37.2
     # via twine
 recommonmark==0.7.1
     # via -r requirements/dev-requirements.in
@@ -138,7 +138,7 @@ smmap==5.0.0
     # via gitdb
 snowballstemmer==2.2.0
     # via sphinx
-sphinx==5.1.1
+sphinx==5.2.3
     # via
     #   -r requirements/dev-requirements.in
     #   recommonmark
@@ -161,7 +161,7 @@ tomli==2.0.1
     # via
     #   pytest
     #   tox
-tomlkit==0.11.4
+tomlkit==0.11.5
     # via python-semantic-release
 tox==3.26.0
     # via -r requirements/dev-requirements.in


### PR DESCRIPTION
This PR provides recompiled deps for all outdated       package versions. It was opened after the committed deps       were successfully compiled and all tests passed with the       new versions. It should be merged as soon as possible to       avoid any security issues due to outdated dependencies.