### PR TITLE
Update deps

### DIFF
--- a/requirements/dev-requirements-py310.txt
+++ b/requirements/dev-requirements-py310.txt
@@ -46,13 +46,13 @@ filelock==3.8.0
     #   virtualenv
 gitdb==4.0.9
     # via gitpython
-gitpython==3.1.27
+gitpython==3.1.29
     # via python-semantic-release
 idna==3.4
     # via requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==4.12.0
+importlib-metadata==5.0.0
     # via twine
 iniconfig==1.1.1
     # via pytest
@@ -102,9 +102,9 @@ pytest==7.1.3
     # via -r requirements/dev-requirements.in
 python-gitlab==3.10.0
     # via python-semantic-release
-python-semantic-release==7.32.0
+python-semantic-release==7.32.1
     # via -r requirements/dev-requirements.in
-pytz==2022.2.1
+pytz==2022.4
     # via babel
 readme-renderer==37.2
     # via twine
@@ -117,7 +117,7 @@ requests==2.28.1
     #   requests-toolbelt
     #   sphinx
     #   twine
-requests-toolbelt==0.9.1
+requests-toolbelt==0.10.0
     # via
     #   python-gitlab
     #   twine
@@ -176,5 +176,5 @@ webencodings==0.5.1
     # via bleach
 wheel==0.37.1
     # via python-semantic-release
-zipp==3.8.1
+zipp==3.9.0
     # via importlib-metadata

--- a/requirements/dev-requirements-py37.txt
+++ b/requirements/dev-requirements-py37.txt
@@ -46,13 +46,13 @@ filelock==3.8.0
     #   virtualenv
 gitdb==4.0.9
     # via gitpython
-gitpython==3.1.27
+gitpython==3.1.29
     # via python-semantic-release
 idna==3.4
     # via requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==4.12.0
+importlib-metadata==5.0.0
     # via
     #   click
     #   keyring
@@ -110,9 +110,9 @@ pytest==7.1.3
     # via -r requirements/dev-requirements.in
 python-gitlab==3.10.0
     # via python-semantic-release
-python-semantic-release==7.32.0
+python-semantic-release==7.32.1
     # via -r requirements/dev-requirements.in
-pytz==2022.2.1
+pytz==2022.4
     # via babel
 readme-renderer==37.2
     # via twine
@@ -125,7 +125,7 @@ requests==2.28.1
     #   requests-toolbelt
     #   sphinx
     #   twine
-requests-toolbelt==0.9.1
+requests-toolbelt==0.10.0
     # via
     #   python-gitlab
     #   twine
@@ -174,7 +174,7 @@ tqdm==4.64.1
     # via twine
 twine==3.8.0
     # via python-semantic-release
-typing-extensions==4.3.0
+typing-extensions==4.4.0
     # via
     #   gitpython
     #   importlib-metadata
@@ -188,5 +188,5 @@ webencodings==0.5.1
     # via bleach
 wheel==0.37.1
     # via python-semantic-release
-zipp==3.8.1
+zipp==3.9.0
     # via importlib-metadata

--- a/requirements/dev-requirements-py38.txt
+++ b/requirements/dev-requirements-py38.txt
@@ -46,13 +46,13 @@ filelock==3.8.0
     #   virtualenv
 gitdb==4.0.9
     # via gitpython
-gitpython==3.1.27
+gitpython==3.1.29
     # via python-semantic-release
 idna==3.4
     # via requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==4.12.0
+importlib-metadata==5.0.0
     # via
     #   keyring
     #   sphinx
@@ -105,9 +105,9 @@ pytest==7.1.3
     # via -r requirements/dev-requirements.in
 python-gitlab==3.10.0
     # via python-semantic-release
-python-semantic-release==7.32.0
+python-semantic-release==7.32.1
     # via -r requirements/dev-requirements.in
-pytz==2022.2.1
+pytz==2022.4
     # via babel
 readme-renderer==37.2
     # via twine
@@ -120,7 +120,7 @@ requests==2.28.1
     #   requests-toolbelt
     #   sphinx
     #   twine
-requests-toolbelt==0.9.1
+requests-toolbelt==0.10.0
     # via
     #   python-gitlab
     #   twine
@@ -179,5 +179,5 @@ webencodings==0.5.1
     # via bleach
 wheel==0.37.1
     # via python-semantic-release
-zipp==3.8.1
+zipp==3.9.0
     # via importlib-metadata

--- a/requirements/dev-requirements-py39.txt
+++ b/requirements/dev-requirements-py39.txt
@@ -46,13 +46,13 @@ filelock==3.8.0
     #   virtualenv
 gitdb==4.0.9
     # via gitpython
-gitpython==3.1.27
+gitpython==3.1.29
     # via python-semantic-release
 idna==3.4
     # via requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==4.12.0
+importlib-metadata==5.0.0
     # via
     #   keyring
     #   sphinx
@@ -105,9 +105,9 @@ pytest==7.1.3
     # via -r requirements/dev-requirements.in
 python-gitlab==3.10.0
     # via python-semantic-release
-python-semantic-release==7.32.0
+python-semantic-release==7.32.1
     # via -r requirements/dev-requirements.in
-pytz==2022.2.1
+pytz==2022.4
     # via babel
 readme-renderer==37.2
     # via twine
@@ -120,7 +120,7 @@ requests==2.28.1
     #   requests-toolbelt
     #   sphinx
     #   twine
-requests-toolbelt==0.9.1
+requests-toolbelt==0.10.0
     # via
     #   python-gitlab
     #   twine
@@ -179,5 +179,5 @@ webencodings==0.5.1
     # via bleach
 wheel==0.37.1
     # via python-semantic-release
-zipp==3.8.1
+zipp==3.9.0
     # via importlib-metadata


### PR DESCRIPTION
This PR provides recompiled deps for all outdated       package versions. It was opened after the committed deps       were successfully compiled and all tests passed with the       new versions. It should be merged as soon as possible to       avoid any security issues due to outdated dependencies.