### PR TITLE
Update deps

### DIFF
--- a/requirements/dev-requirements-py310.txt
+++ b/requirements/dev-requirements-py310.txt
@@ -24,7 +24,7 @@ click==8.1.3
     #   python-semantic-release
 click-log==0.4.0
     # via python-semantic-release
-colorama==0.4.5
+colorama==0.4.6
     # via twine
 commonmark==0.9.1
     # via recommonmark
@@ -40,6 +40,8 @@ docutils==0.17.1
     #   sphinx-rtd-theme
 dotty-dict==1.3.1
     # via python-semantic-release
+exceptiongroup==1.0.0
+    # via pytest
 filelock==3.8.0
     # via
     #   tox
@@ -70,7 +72,7 @@ keyring==23.9.3
     # via twine
 markupsafe==2.1.1
     # via jinja2
-more-itertools==8.14.0
+more-itertools==9.0.0
     # via jaraco-classes
 packaging==21.3
     # via
@@ -87,9 +89,7 @@ pluggy==1.0.0
     #   pytest
     #   tox
 py==1.11.0
-    # via
-    #   pytest
-    #   tox
+    # via tox
 pycparser==2.21
     # via cffi
 pygments==2.13.0
@@ -98,15 +98,15 @@ pygments==2.13.0
     #   sphinx
 pyparsing==3.0.9
     # via packaging
-pytest==7.1.3
+pytest==7.2.0
     # via -r requirements/dev-requirements.in
-python-gitlab==3.10.0
+python-gitlab==3.11.0
     # via python-semantic-release
-python-semantic-release==7.32.1
+python-semantic-release==7.32.2
     # via -r requirements/dev-requirements.in
-pytz==2022.4
+pytz==2022.6
     # via babel
-readme-renderer==37.2
+readme-renderer==37.3
     # via twine
 recommonmark==0.7.1
     # via -r requirements/dev-requirements.in
@@ -117,7 +117,7 @@ requests==2.28.1
     #   requests-toolbelt
     #   sphinx
     #   twine
-requests-toolbelt==0.10.0
+requests-toolbelt==0.10.1
     # via
     #   python-gitlab
     #   twine
@@ -135,7 +135,7 @@ smmap==5.0.0
     # via gitdb
 snowballstemmer==2.2.0
     # via sphinx
-sphinx==5.2.3
+sphinx==5.3.0
     # via
     #   -r requirements/dev-requirements.in
     #   recommonmark
@@ -158,9 +158,9 @@ tomli==2.0.1
     # via
     #   pytest
     #   tox
-tomlkit==0.11.5
+tomlkit==0.11.6
     # via python-semantic-release
-tox==3.26.0
+tox==3.27.0
     # via -r requirements/dev-requirements.in
 tqdm==4.64.1
     # via twine
@@ -170,11 +170,11 @@ urllib3==1.26.12
     # via
     #   requests
     #   twine
-virtualenv==20.16.5
+virtualenv==20.16.6
     # via tox
 webencodings==0.5.1
     # via bleach
 wheel==0.37.1
     # via python-semantic-release
-zipp==3.9.0
+zipp==3.10.0
     # via importlib-metadata

--- a/requirements/dev-requirements-py37.txt
+++ b/requirements/dev-requirements-py37.txt
@@ -24,7 +24,7 @@ click==8.1.3
     #   python-semantic-release
 click-log==0.4.0
     # via python-semantic-release
-colorama==0.4.5
+colorama==0.4.6
     # via twine
 commonmark==0.9.1
     # via recommonmark
@@ -40,6 +40,8 @@ docutils==0.17.1
     #   sphinx-rtd-theme
 dotty-dict==1.3.1
     # via python-semantic-release
+exceptiongroup==1.0.0
+    # via pytest
 filelock==3.8.0
     # via
     #   tox
@@ -78,7 +80,7 @@ keyring==23.9.3
     # via twine
 markupsafe==2.1.1
     # via jinja2
-more-itertools==8.14.0
+more-itertools==9.0.0
     # via jaraco-classes
 packaging==21.3
     # via
@@ -95,9 +97,7 @@ pluggy==1.0.0
     #   pytest
     #   tox
 py==1.11.0
-    # via
-    #   pytest
-    #   tox
+    # via tox
 pycparser==2.21
     # via cffi
 pygments==2.13.0
@@ -106,15 +106,15 @@ pygments==2.13.0
     #   sphinx
 pyparsing==3.0.9
     # via packaging
-pytest==7.1.3
+pytest==7.2.0
     # via -r requirements/dev-requirements.in
-python-gitlab==3.10.0
+python-gitlab==3.11.0
     # via python-semantic-release
-python-semantic-release==7.32.1
+python-semantic-release==7.32.2
     # via -r requirements/dev-requirements.in
-pytz==2022.4
+pytz==2022.6
     # via babel
-readme-renderer==37.2
+readme-renderer==37.3
     # via twine
 recommonmark==0.7.1
     # via -r requirements/dev-requirements.in
@@ -125,7 +125,7 @@ requests==2.28.1
     #   requests-toolbelt
     #   sphinx
     #   twine
-requests-toolbelt==0.10.0
+requests-toolbelt==0.10.1
     # via
     #   python-gitlab
     #   twine
@@ -143,7 +143,7 @@ smmap==5.0.0
     # via gitdb
 snowballstemmer==2.2.0
     # via sphinx
-sphinx==5.2.3
+sphinx==5.3.0
     # via
     #   -r requirements/dev-requirements.in
     #   recommonmark
@@ -166,9 +166,9 @@ tomli==2.0.1
     # via
     #   pytest
     #   tox
-tomlkit==0.11.5
+tomlkit==0.11.6
     # via python-semantic-release
-tox==3.26.0
+tox==3.27.0
     # via -r requirements/dev-requirements.in
 tqdm==4.64.1
     # via twine
@@ -182,11 +182,11 @@ urllib3==1.26.12
     # via
     #   requests
     #   twine
-virtualenv==20.16.5
+virtualenv==20.16.6
     # via tox
 webencodings==0.5.1
     # via bleach
 wheel==0.37.1
     # via python-semantic-release
-zipp==3.9.0
+zipp==3.10.0
     # via importlib-metadata

--- a/requirements/dev-requirements-py38.txt
+++ b/requirements/dev-requirements-py38.txt
@@ -24,7 +24,7 @@ click==8.1.3
     #   python-semantic-release
 click-log==0.4.0
     # via python-semantic-release
-colorama==0.4.5
+colorama==0.4.6
     # via twine
 commonmark==0.9.1
     # via recommonmark
@@ -40,6 +40,8 @@ docutils==0.17.1
     #   sphinx-rtd-theme
 dotty-dict==1.3.1
     # via python-semantic-release
+exceptiongroup==1.0.0
+    # via pytest
 filelock==3.8.0
     # via
     #   tox
@@ -73,7 +75,7 @@ keyring==23.9.3
     # via twine
 markupsafe==2.1.1
     # via jinja2
-more-itertools==8.14.0
+more-itertools==9.0.0
     # via jaraco-classes
 packaging==21.3
     # via
@@ -90,9 +92,7 @@ pluggy==1.0.0
     #   pytest
     #   tox
 py==1.11.0
-    # via
-    #   pytest
-    #   tox
+    # via tox
 pycparser==2.21
     # via cffi
 pygments==2.13.0
@@ -101,15 +101,15 @@ pygments==2.13.0
     #   sphinx
 pyparsing==3.0.9
     # via packaging
-pytest==7.1.3
+pytest==7.2.0
     # via -r requirements/dev-requirements.in
-python-gitlab==3.10.0
+python-gitlab==3.11.0
     # via python-semantic-release
-python-semantic-release==7.32.1
+python-semantic-release==7.32.2
     # via -r requirements/dev-requirements.in
-pytz==2022.4
+pytz==2022.6
     # via babel
-readme-renderer==37.2
+readme-renderer==37.3
     # via twine
 recommonmark==0.7.1
     # via -r requirements/dev-requirements.in
@@ -120,7 +120,7 @@ requests==2.28.1
     #   requests-toolbelt
     #   sphinx
     #   twine
-requests-toolbelt==0.10.0
+requests-toolbelt==0.10.1
     # via
     #   python-gitlab
     #   twine
@@ -138,7 +138,7 @@ smmap==5.0.0
     # via gitdb
 snowballstemmer==2.2.0
     # via sphinx
-sphinx==5.2.3
+sphinx==5.3.0
     # via
     #   -r requirements/dev-requirements.in
     #   recommonmark
@@ -161,9 +161,9 @@ tomli==2.0.1
     # via
     #   pytest
     #   tox
-tomlkit==0.11.5
+tomlkit==0.11.6
     # via python-semantic-release
-tox==3.26.0
+tox==3.27.0
     # via -r requirements/dev-requirements.in
 tqdm==4.64.1
     # via twine
@@ -173,11 +173,11 @@ urllib3==1.26.12
     # via
     #   requests
     #   twine
-virtualenv==20.16.5
+virtualenv==20.16.6
     # via tox
 webencodings==0.5.1
     # via bleach
 wheel==0.37.1
     # via python-semantic-release
-zipp==3.9.0
+zipp==3.10.0
     # via importlib-metadata

--- a/requirements/dev-requirements-py39.txt
+++ b/requirements/dev-requirements-py39.txt
@@ -24,7 +24,7 @@ click==8.1.3
     #   python-semantic-release
 click-log==0.4.0
     # via python-semantic-release
-colorama==0.4.5
+colorama==0.4.6
     # via twine
 commonmark==0.9.1
     # via recommonmark
@@ -40,6 +40,8 @@ docutils==0.17.1
     #   sphinx-rtd-theme
 dotty-dict==1.3.1
     # via python-semantic-release
+exceptiongroup==1.0.0
+    # via pytest
 filelock==3.8.0
     # via
     #   tox
@@ -73,7 +75,7 @@ keyring==23.9.3
     # via twine
 markupsafe==2.1.1
     # via jinja2
-more-itertools==8.14.0
+more-itertools==9.0.0
     # via jaraco-classes
 packaging==21.3
     # via
@@ -90,9 +92,7 @@ pluggy==1.0.0
     #   pytest
     #   tox
 py==1.11.0
-    # via
-    #   pytest
-    #   tox
+    # via tox
 pycparser==2.21
     # via cffi
 pygments==2.13.0
@@ -101,15 +101,15 @@ pygments==2.13.0
     #   sphinx
 pyparsing==3.0.9
     # via packaging
-pytest==7.1.3
+pytest==7.2.0
     # via -r requirements/dev-requirements.in
-python-gitlab==3.10.0
+python-gitlab==3.11.0
     # via python-semantic-release
-python-semantic-release==7.32.1
+python-semantic-release==7.32.2
     # via -r requirements/dev-requirements.in
-pytz==2022.4
+pytz==2022.6
     # via babel
-readme-renderer==37.2
+readme-renderer==37.3
     # via twine
 recommonmark==0.7.1
     # via -r requirements/dev-requirements.in
@@ -120,7 +120,7 @@ requests==2.28.1
     #   requests-toolbelt
     #   sphinx
     #   twine
-requests-toolbelt==0.10.0
+requests-toolbelt==0.10.1
     # via
     #   python-gitlab
     #   twine
@@ -138,7 +138,7 @@ smmap==5.0.0
     # via gitdb
 snowballstemmer==2.2.0
     # via sphinx
-sphinx==5.2.3
+sphinx==5.3.0
     # via
     #   -r requirements/dev-requirements.in
     #   recommonmark
@@ -161,9 +161,9 @@ tomli==2.0.1
     # via
     #   pytest
     #   tox
-tomlkit==0.11.5
+tomlkit==0.11.6
     # via python-semantic-release
-tox==3.26.0
+tox==3.27.0
     # via -r requirements/dev-requirements.in
 tqdm==4.64.1
     # via twine
@@ -173,11 +173,11 @@ urllib3==1.26.12
     # via
     #   requests
     #   twine
-virtualenv==20.16.5
+virtualenv==20.16.6
     # via tox
 webencodings==0.5.1
     # via bleach
 wheel==0.37.1
     # via python-semantic-release
-zipp==3.9.0
+zipp==3.10.0
     # via importlib-metadata


### PR DESCRIPTION
This PR provides recompiled deps for all outdated       package versions. It was opened after the committed deps       were successfully compiled and all tests passed with the       new versions. It should be merged as soon as possible to       avoid any security issues due to outdated dependencies.