### PR TITLE
Update deps

### DIFF
--- a/requirements/dev-requirements-py310.txt
+++ b/requirements/dev-requirements-py310.txt
@@ -8,7 +8,7 @@ alabaster==0.7.12
     # via sphinx
 attrs==22.1.0
     # via pytest
-babel==2.10.3
+babel==2.11.0
     # via sphinx
 bleach==5.0.1
     # via readme-renderer
@@ -28,7 +28,7 @@ colorama==0.4.6
     # via twine
 commonmark==0.9.1
     # via recommonmark
-cryptography==38.0.1
+cryptography==38.0.3
     # via secretstorage
 distlib==0.3.6
     # via virtualenv
@@ -40,7 +40,7 @@ docutils==0.17.1
     #   sphinx-rtd-theme
 dotty-dict==1.3.1
     # via python-semantic-release
-exceptiongroup==1.0.0
+exceptiongroup==1.0.3
     # via pytest
 filelock==3.8.0
     # via
@@ -55,7 +55,9 @@ idna==3.4
 imagesize==1.4.1
     # via sphinx
 importlib-metadata==5.0.0
-    # via twine
+    # via
+    #   keyring
+    #   twine
 iniconfig==1.1.1
     # via pytest
 invoke==1.7.3
@@ -68,7 +70,7 @@ jeepney==0.8.0
     #   secretstorage
 jinja2==3.1.2
     # via sphinx
-keyring==23.9.3
+keyring==23.11.0
     # via twine
 markupsafe==2.1.1
     # via jinja2
@@ -82,7 +84,7 @@ packaging==21.3
     #   tox
 pkginfo==1.8.3
     # via twine
-platformdirs==2.5.2
+platformdirs==2.5.4
     # via virtualenv
 pluggy==1.0.0
     # via
@@ -140,7 +142,7 @@ sphinx==5.3.0
     #   -r requirements/dev-requirements.in
     #   recommonmark
     #   sphinx-rtd-theme
-sphinx-rtd-theme==1.0.0
+sphinx-rtd-theme==1.1.1
     # via -r requirements/dev-requirements.in
 sphinxcontrib-applehelp==1.0.2
     # via sphinx
@@ -160,7 +162,7 @@ tomli==2.0.1
     #   tox
 tomlkit==0.11.6
     # via python-semantic-release
-tox==3.27.0
+tox==3.27.1
     # via -r requirements/dev-requirements.in
 tqdm==4.64.1
     # via twine
@@ -170,11 +172,11 @@ urllib3==1.26.12
     # via
     #   requests
     #   twine
-virtualenv==20.16.6
+virtualenv==20.16.7
     # via tox
 webencodings==0.5.1
     # via bleach
-wheel==0.37.1
+wheel==0.38.4
     # via python-semantic-release
 zipp==3.10.0
     # via importlib-metadata

--- a/requirements/dev-requirements-py37.txt
+++ b/requirements/dev-requirements-py37.txt
@@ -8,7 +8,7 @@ alabaster==0.7.12
     # via sphinx
 attrs==22.1.0
     # via pytest
-babel==2.10.3
+babel==2.11.0
     # via sphinx
 bleach==5.0.1
     # via readme-renderer
@@ -28,7 +28,7 @@ colorama==0.4.6
     # via twine
 commonmark==0.9.1
     # via recommonmark
-cryptography==38.0.1
+cryptography==38.0.3
     # via secretstorage
 distlib==0.3.6
     # via virtualenv
@@ -40,7 +40,7 @@ docutils==0.17.1
     #   sphinx-rtd-theme
 dotty-dict==1.3.1
     # via python-semantic-release
-exceptiongroup==1.0.0
+exceptiongroup==1.0.3
     # via pytest
 filelock==3.8.0
     # via
@@ -76,7 +76,7 @@ jeepney==0.8.0
     #   secretstorage
 jinja2==3.1.2
     # via sphinx
-keyring==23.9.3
+keyring==23.11.0
     # via twine
 markupsafe==2.1.1
     # via jinja2
@@ -90,7 +90,7 @@ packaging==21.3
     #   tox
 pkginfo==1.8.3
     # via twine
-platformdirs==2.5.2
+platformdirs==2.5.4
     # via virtualenv
 pluggy==1.0.0
     # via
@@ -148,7 +148,7 @@ sphinx==5.3.0
     #   -r requirements/dev-requirements.in
     #   recommonmark
     #   sphinx-rtd-theme
-sphinx-rtd-theme==1.0.0
+sphinx-rtd-theme==1.1.1
     # via -r requirements/dev-requirements.in
 sphinxcontrib-applehelp==1.0.2
     # via sphinx
@@ -168,7 +168,7 @@ tomli==2.0.1
     #   tox
 tomlkit==0.11.6
     # via python-semantic-release
-tox==3.27.0
+tox==3.27.1
     # via -r requirements/dev-requirements.in
 tqdm==4.64.1
     # via twine
@@ -182,11 +182,11 @@ urllib3==1.26.12
     # via
     #   requests
     #   twine
-virtualenv==20.16.6
+virtualenv==20.16.7
     # via tox
 webencodings==0.5.1
     # via bleach
-wheel==0.37.1
+wheel==0.38.4
     # via python-semantic-release
 zipp==3.10.0
     # via importlib-metadata

--- a/requirements/dev-requirements-py38.txt
+++ b/requirements/dev-requirements-py38.txt
@@ -8,7 +8,7 @@ alabaster==0.7.12
     # via sphinx
 attrs==22.1.0
     # via pytest
-babel==2.10.3
+babel==2.11.0
     # via sphinx
 bleach==5.0.1
     # via readme-renderer
@@ -28,7 +28,7 @@ colorama==0.4.6
     # via twine
 commonmark==0.9.1
     # via recommonmark
-cryptography==38.0.1
+cryptography==38.0.3
     # via secretstorage
 distlib==0.3.6
     # via virtualenv
@@ -40,7 +40,7 @@ docutils==0.17.1
     #   sphinx-rtd-theme
 dotty-dict==1.3.1
     # via python-semantic-release
-exceptiongroup==1.0.0
+exceptiongroup==1.0.3
     # via pytest
 filelock==3.8.0
     # via
@@ -71,7 +71,7 @@ jeepney==0.8.0
     #   secretstorage
 jinja2==3.1.2
     # via sphinx
-keyring==23.9.3
+keyring==23.11.0
     # via twine
 markupsafe==2.1.1
     # via jinja2
@@ -85,7 +85,7 @@ packaging==21.3
     #   tox
 pkginfo==1.8.3
     # via twine
-platformdirs==2.5.2
+platformdirs==2.5.4
     # via virtualenv
 pluggy==1.0.0
     # via
@@ -143,7 +143,7 @@ sphinx==5.3.0
     #   -r requirements/dev-requirements.in
     #   recommonmark
     #   sphinx-rtd-theme
-sphinx-rtd-theme==1.0.0
+sphinx-rtd-theme==1.1.1
     # via -r requirements/dev-requirements.in
 sphinxcontrib-applehelp==1.0.2
     # via sphinx
@@ -163,7 +163,7 @@ tomli==2.0.1
     #   tox
 tomlkit==0.11.6
     # via python-semantic-release
-tox==3.27.0
+tox==3.27.1
     # via -r requirements/dev-requirements.in
 tqdm==4.64.1
     # via twine
@@ -173,11 +173,11 @@ urllib3==1.26.12
     # via
     #   requests
     #   twine
-virtualenv==20.16.6
+virtualenv==20.16.7
     # via tox
 webencodings==0.5.1
     # via bleach
-wheel==0.37.1
+wheel==0.38.4
     # via python-semantic-release
 zipp==3.10.0
     # via importlib-metadata

--- a/requirements/dev-requirements-py39.txt
+++ b/requirements/dev-requirements-py39.txt
@@ -8,7 +8,7 @@ alabaster==0.7.12
     # via sphinx
 attrs==22.1.0
     # via pytest
-babel==2.10.3
+babel==2.11.0
     # via sphinx
 bleach==5.0.1
     # via readme-renderer
@@ -28,7 +28,7 @@ colorama==0.4.6
     # via twine
 commonmark==0.9.1
     # via recommonmark
-cryptography==38.0.1
+cryptography==38.0.3
     # via secretstorage
 distlib==0.3.6
     # via virtualenv
@@ -40,7 +40,7 @@ docutils==0.17.1
     #   sphinx-rtd-theme
 dotty-dict==1.3.1
     # via python-semantic-release
-exceptiongroup==1.0.0
+exceptiongroup==1.0.3
     # via pytest
 filelock==3.8.0
     # via
@@ -71,7 +71,7 @@ jeepney==0.8.0
     #   secretstorage
 jinja2==3.1.2
     # via sphinx
-keyring==23.9.3
+keyring==23.11.0
     # via twine
 markupsafe==2.1.1
     # via jinja2
@@ -85,7 +85,7 @@ packaging==21.3
     #   tox
 pkginfo==1.8.3
     # via twine
-platformdirs==2.5.2
+platformdirs==2.5.4
     # via virtualenv
 pluggy==1.0.0
     # via
@@ -143,7 +143,7 @@ sphinx==5.3.0
     #   -r requirements/dev-requirements.in
     #   recommonmark
     #   sphinx-rtd-theme
-sphinx-rtd-theme==1.0.0
+sphinx-rtd-theme==1.1.1
     # via -r requirements/dev-requirements.in
 sphinxcontrib-applehelp==1.0.2
     # via sphinx
@@ -163,7 +163,7 @@ tomli==2.0.1
     #   tox
 tomlkit==0.11.6
     # via python-semantic-release
-tox==3.27.0
+tox==3.27.1
     # via -r requirements/dev-requirements.in
 tqdm==4.64.1
     # via twine
@@ -173,11 +173,11 @@ urllib3==1.26.12
     # via
     #   requests
     #   twine
-virtualenv==20.16.6
+virtualenv==20.16.7
     # via tox
 webencodings==0.5.1
     # via bleach
-wheel==0.37.1
+wheel==0.38.4
     # via python-semantic-release
 zipp==3.10.0
     # via importlib-metadata


### PR DESCRIPTION
This PR provides recompiled deps for all outdated       package versions. It was opened after the committed deps       were successfully compiled and all tests passed with the       new versions. It should be merged as soon as possible to       avoid any security issues due to outdated dependencies.