### PR TITLE
Update deps

### DIFF
--- a/requirements/dev-requirements-py310.txt
+++ b/requirements/dev-requirements-py310.txt
@@ -28,7 +28,7 @@ colorama==0.4.6
     # via twine
 commonmark==0.9.1
     # via recommonmark
-cryptography==38.0.3
+cryptography==38.0.4
     # via secretstorage
 distlib==0.3.6
     # via virtualenv
@@ -40,13 +40,13 @@ docutils==0.17.1
     #   sphinx-rtd-theme
 dotty-dict==1.3.1
     # via python-semantic-release
-exceptiongroup==1.0.3
+exceptiongroup==1.0.4
     # via pytest
 filelock==3.8.0
     # via
     #   tox
     #   virtualenv
-gitdb==4.0.9
+gitdb==4.0.10
     # via gitpython
 gitpython==3.1.29
     # via python-semantic-release
@@ -54,7 +54,7 @@ idna==3.4
     # via requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==5.0.0
+importlib-metadata==5.1.0
     # via
     #   keyring
     #   twine
@@ -82,7 +82,7 @@ packaging==21.3
     #   python-semantic-release
     #   sphinx
     #   tox
-pkginfo==1.8.3
+pkginfo==1.9.2
     # via twine
 platformdirs==2.5.4
     # via virtualenv
@@ -102,7 +102,7 @@ pyparsing==3.0.9
     # via packaging
 pytest==7.2.0
     # via -r requirements/dev-requirements.in
-python-gitlab==3.11.0
+python-gitlab==3.12.0
     # via python-semantic-release
 python-semantic-release==7.32.2
     # via -r requirements/dev-requirements.in
@@ -168,15 +168,15 @@ tqdm==4.64.1
     # via twine
 twine==3.8.0
     # via python-semantic-release
-urllib3==1.26.12
+urllib3==1.26.13
     # via
     #   requests
     #   twine
-virtualenv==20.16.7
+virtualenv==20.17.0
     # via tox
 webencodings==0.5.1
     # via bleach
 wheel==0.38.4
     # via python-semantic-release
-zipp==3.10.0
+zipp==3.11.0
     # via importlib-metadata

--- a/requirements/dev-requirements-py37.txt
+++ b/requirements/dev-requirements-py37.txt
@@ -28,7 +28,7 @@ colorama==0.4.6
     # via twine
 commonmark==0.9.1
     # via recommonmark
-cryptography==38.0.3
+cryptography==38.0.4
     # via secretstorage
 distlib==0.3.6
     # via virtualenv
@@ -40,13 +40,13 @@ docutils==0.17.1
     #   sphinx-rtd-theme
 dotty-dict==1.3.1
     # via python-semantic-release
-exceptiongroup==1.0.3
+exceptiongroup==1.0.4
     # via pytest
 filelock==3.8.0
     # via
     #   tox
     #   virtualenv
-gitdb==4.0.9
+gitdb==4.0.10
     # via gitpython
 gitpython==3.1.29
     # via python-semantic-release
@@ -54,7 +54,7 @@ idna==3.4
     # via requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==5.0.0
+importlib-metadata==5.1.0
     # via
     #   click
     #   keyring
@@ -88,7 +88,7 @@ packaging==21.3
     #   python-semantic-release
     #   sphinx
     #   tox
-pkginfo==1.8.3
+pkginfo==1.9.2
     # via twine
 platformdirs==2.5.4
     # via virtualenv
@@ -108,7 +108,7 @@ pyparsing==3.0.9
     # via packaging
 pytest==7.2.0
     # via -r requirements/dev-requirements.in
-python-gitlab==3.11.0
+python-gitlab==3.12.0
     # via python-semantic-release
 python-semantic-release==7.32.2
     # via -r requirements/dev-requirements.in
@@ -178,15 +178,15 @@ typing-extensions==4.4.0
     # via
     #   gitpython
     #   importlib-metadata
-urllib3==1.26.12
+urllib3==1.26.13
     # via
     #   requests
     #   twine
-virtualenv==20.16.7
+virtualenv==20.17.0
     # via tox
 webencodings==0.5.1
     # via bleach
 wheel==0.38.4
     # via python-semantic-release
-zipp==3.10.0
+zipp==3.11.0
     # via importlib-metadata

--- a/requirements/dev-requirements-py38.txt
+++ b/requirements/dev-requirements-py38.txt
@@ -28,7 +28,7 @@ colorama==0.4.6
     # via twine
 commonmark==0.9.1
     # via recommonmark
-cryptography==38.0.3
+cryptography==38.0.4
     # via secretstorage
 distlib==0.3.6
     # via virtualenv
@@ -40,13 +40,13 @@ docutils==0.17.1
     #   sphinx-rtd-theme
 dotty-dict==1.3.1
     # via python-semantic-release
-exceptiongroup==1.0.3
+exceptiongroup==1.0.4
     # via pytest
 filelock==3.8.0
     # via
     #   tox
     #   virtualenv
-gitdb==4.0.9
+gitdb==4.0.10
     # via gitpython
 gitpython==3.1.29
     # via python-semantic-release
@@ -54,7 +54,7 @@ idna==3.4
     # via requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==5.0.0
+importlib-metadata==5.1.0
     # via
     #   keyring
     #   sphinx
@@ -83,7 +83,7 @@ packaging==21.3
     #   python-semantic-release
     #   sphinx
     #   tox
-pkginfo==1.8.3
+pkginfo==1.9.2
     # via twine
 platformdirs==2.5.4
     # via virtualenv
@@ -103,7 +103,7 @@ pyparsing==3.0.9
     # via packaging
 pytest==7.2.0
     # via -r requirements/dev-requirements.in
-python-gitlab==3.11.0
+python-gitlab==3.12.0
     # via python-semantic-release
 python-semantic-release==7.32.2
     # via -r requirements/dev-requirements.in
@@ -169,15 +169,15 @@ tqdm==4.64.1
     # via twine
 twine==3.8.0
     # via python-semantic-release
-urllib3==1.26.12
+urllib3==1.26.13
     # via
     #   requests
     #   twine
-virtualenv==20.16.7
+virtualenv==20.17.0
     # via tox
 webencodings==0.5.1
     # via bleach
 wheel==0.38.4
     # via python-semantic-release
-zipp==3.10.0
+zipp==3.11.0
     # via importlib-metadata

--- a/requirements/dev-requirements-py39.txt
+++ b/requirements/dev-requirements-py39.txt
@@ -28,7 +28,7 @@ colorama==0.4.6
     # via twine
 commonmark==0.9.1
     # via recommonmark
-cryptography==38.0.3
+cryptography==38.0.4
     # via secretstorage
 distlib==0.3.6
     # via virtualenv
@@ -40,13 +40,13 @@ docutils==0.17.1
     #   sphinx-rtd-theme
 dotty-dict==1.3.1
     # via python-semantic-release
-exceptiongroup==1.0.3
+exceptiongroup==1.0.4
     # via pytest
 filelock==3.8.0
     # via
     #   tox
     #   virtualenv
-gitdb==4.0.9
+gitdb==4.0.10
     # via gitpython
 gitpython==3.1.29
     # via python-semantic-release
@@ -54,7 +54,7 @@ idna==3.4
     # via requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==5.0.0
+importlib-metadata==5.1.0
     # via
     #   keyring
     #   sphinx
@@ -83,7 +83,7 @@ packaging==21.3
     #   python-semantic-release
     #   sphinx
     #   tox
-pkginfo==1.8.3
+pkginfo==1.9.2
     # via twine
 platformdirs==2.5.4
     # via virtualenv
@@ -103,7 +103,7 @@ pyparsing==3.0.9
     # via packaging
 pytest==7.2.0
     # via -r requirements/dev-requirements.in
-python-gitlab==3.11.0
+python-gitlab==3.12.0
     # via python-semantic-release
 python-semantic-release==7.32.2
     # via -r requirements/dev-requirements.in
@@ -169,15 +169,15 @@ tqdm==4.64.1
     # via twine
 twine==3.8.0
     # via python-semantic-release
-urllib3==1.26.12
+urllib3==1.26.13
     # via
     #   requests
     #   twine
-virtualenv==20.16.7
+virtualenv==20.17.0
     # via tox
 webencodings==0.5.1
     # via bleach
 wheel==0.38.4
     # via python-semantic-release
-zipp==3.10.0
+zipp==3.11.0
     # via importlib-metadata


### PR DESCRIPTION
This PR provides recompiled deps for all outdated       package versions. It was opened after the committed deps       were successfully compiled and all tests passed with the       new versions. It should be merged as soon as possible to       avoid any security issues due to outdated dependencies.