### PR TITLE
Update deps

### DIFF
--- a/requirements/dev-requirements-py310.txt
+++ b/requirements/dev-requirements-py310.txt
@@ -4,15 +4,15 @@
 #
 #    pip-compile --output-file=requirements/dev-requirements-py310.txt requirements/dev-requirements.in
 #
-alabaster==0.7.12
+alabaster==0.7.13
     # via sphinx
-attrs==22.1.0
+attrs==22.2.0
     # via pytest
 babel==2.11.0
     # via sphinx
-bleach==5.0.1
+bleach==6.0.0
     # via readme-renderer
-cachetools==5.2.0
+cachetools==5.3.0
     # via tox
 certifi==2022.12.7
     # via requests
@@ -20,7 +20,7 @@ cffi==1.15.1
     # via cryptography
 chardet==5.1.0
     # via tox
-charset-normalizer==2.1.1
+charset-normalizer==3.0.1
     # via requests
 click==8.1.3
     # via
@@ -34,11 +34,11 @@ colorama==0.4.6
     #   twine
 commonmark==0.9.1
     # via recommonmark
-cryptography==38.0.4
+cryptography==39.0.1
     # via secretstorage
 distlib==0.3.6
     # via virtualenv
-docutils==0.17.1
+docutils==0.18.1
     # via
     #   readme-renderer
     #   recommonmark
@@ -46,25 +46,25 @@ docutils==0.17.1
     #   sphinx-rtd-theme
 dotty-dict==1.3.1
     # via python-semantic-release
-exceptiongroup==1.0.4
+exceptiongroup==1.1.0
     # via pytest
-filelock==3.8.2
+filelock==3.9.0
     # via
     #   tox
     #   virtualenv
 gitdb==4.0.10
     # via gitpython
-gitpython==3.1.29
+gitpython==3.1.30
     # via python-semantic-release
 idna==3.4
     # via requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==5.1.0
+importlib-metadata==6.0.0
     # via
     #   keyring
     #   twine
-iniconfig==1.1.1
+iniconfig==2.0.0
     # via pytest
 invoke==1.7.3
     # via python-semantic-release
@@ -76,22 +76,22 @@ jeepney==0.8.0
     #   secretstorage
 jinja2==3.1.2
     # via sphinx
-keyring==23.11.0
+keyring==23.13.1
     # via twine
-markupsafe==2.1.1
+markupsafe==2.1.2
     # via jinja2
 more-itertools==9.0.0
     # via jaraco-classes
-packaging==22.0
+packaging==23.0
     # via
     #   pyproject-api
     #   pytest
     #   python-semantic-release
     #   sphinx
     #   tox
-pkginfo==1.9.2
+pkginfo==1.9.6
     # via twine
-platformdirs==2.6.0
+platformdirs==3.0.0
     # via
     #   tox
     #   virtualenv
@@ -101,25 +101,25 @@ pluggy==1.0.0
     #   tox
 pycparser==2.21
     # via cffi
-pygments==2.13.0
+pygments==2.14.0
     # via
     #   readme-renderer
     #   sphinx
-pyproject-api==1.2.1
+pyproject-api==1.5.0
     # via tox
-pytest==7.2.0
+pytest==7.2.1
     # via -r requirements/dev-requirements.in
-python-gitlab==3.12.0
+python-gitlab==3.13.0
     # via python-semantic-release
-python-semantic-release==7.32.2
+python-semantic-release==7.33.1
     # via -r requirements/dev-requirements.in
-pytz==2022.6
+pytz==2022.7.1
     # via babel
 readme-renderer==37.3
     # via twine
 recommonmark==0.7.1
     # via -r requirements/dev-requirements.in
-requests==2.28.1
+requests==2.28.2
     # via
     #   python-gitlab
     #   python-semantic-release
@@ -142,19 +142,21 @@ smmap==5.0.0
     # via gitdb
 snowballstemmer==2.2.0
     # via sphinx
-sphinx==5.3.0
+sphinx==6.1.3
     # via
     #   -r requirements/dev-requirements.in
     #   recommonmark
     #   sphinx-rtd-theme
-sphinx-rtd-theme==1.1.1
+sphinx-rtd-theme==1.2.0
     # via -r requirements/dev-requirements.in
-sphinxcontrib-applehelp==1.0.2
+sphinxcontrib-applehelp==1.0.4
     # via sphinx
 sphinxcontrib-devhelp==1.0.2
     # via sphinx
-sphinxcontrib-htmlhelp==2.0.0
+sphinxcontrib-htmlhelp==2.0.1
     # via sphinx
+sphinxcontrib-jquery==2.0.0
+    # via sphinx-rtd-theme
 sphinxcontrib-jsmath==1.0.1
     # via sphinx
 sphinxcontrib-qthelp==1.0.3
@@ -168,21 +170,24 @@ tomli==2.0.1
     #   tox
 tomlkit==0.11.6
     # via python-semantic-release
-tox==4.0.10
+tox==4.4.5
     # via -r requirements/dev-requirements.in
 tqdm==4.64.1
     # via twine
 twine==3.8.0
     # via python-semantic-release
-urllib3==1.26.13
+urllib3==1.26.14
     # via
     #   requests
     #   twine
-virtualenv==20.17.1
+virtualenv==20.19.0
     # via tox
 webencodings==0.5.1
     # via bleach
 wheel==0.38.4
     # via python-semantic-release
-zipp==3.11.0
+zipp==3.13.0
     # via importlib-metadata
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools

--- a/requirements/dev-requirements-py37.txt
+++ b/requirements/dev-requirements-py37.txt
@@ -4,15 +4,15 @@
 #
 #    pip-compile --output-file=requirements/dev-requirements-py37.txt requirements/dev-requirements.in
 #
-alabaster==0.7.12
+alabaster==0.7.13
     # via sphinx
-attrs==22.1.0
+attrs==22.2.0
     # via pytest
 babel==2.11.0
     # via sphinx
-bleach==5.0.1
+bleach==6.0.0
     # via readme-renderer
-cachetools==5.2.0
+cachetools==5.3.0
     # via tox
 certifi==2022.12.7
     # via requests
@@ -20,7 +20,7 @@ cffi==1.15.1
     # via cryptography
 chardet==5.1.0
     # via tox
-charset-normalizer==2.1.1
+charset-normalizer==3.0.1
     # via requests
 click==8.1.3
     # via
@@ -34,11 +34,11 @@ colorama==0.4.6
     #   twine
 commonmark==0.9.1
     # via recommonmark
-cryptography==38.0.4
+cryptography==39.0.1
     # via secretstorage
 distlib==0.3.6
     # via virtualenv
-docutils==0.17.1
+docutils==0.18.1
     # via
     #   readme-renderer
     #   recommonmark
@@ -46,21 +46,21 @@ docutils==0.17.1
     #   sphinx-rtd-theme
 dotty-dict==1.3.1
     # via python-semantic-release
-exceptiongroup==1.0.4
+exceptiongroup==1.1.0
     # via pytest
-filelock==3.8.2
+filelock==3.9.0
     # via
     #   tox
     #   virtualenv
 gitdb==4.0.10
     # via gitpython
-gitpython==3.1.29
+gitpython==3.1.30
     # via python-semantic-release
 idna==3.4
     # via requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==5.1.0
+importlib-metadata==6.0.0
     # via
     #   click
     #   keyring
@@ -70,7 +70,9 @@ importlib-metadata==5.1.0
     #   tox
     #   twine
     #   virtualenv
-iniconfig==1.1.1
+importlib-resources==5.10.2
+    # via keyring
+iniconfig==2.0.0
     # via pytest
 invoke==1.7.3
     # via python-semantic-release
@@ -82,22 +84,22 @@ jeepney==0.8.0
     #   secretstorage
 jinja2==3.1.2
     # via sphinx
-keyring==23.11.0
+keyring==23.13.1
     # via twine
-markupsafe==2.1.1
+markupsafe==2.1.2
     # via jinja2
 more-itertools==9.0.0
     # via jaraco-classes
-packaging==22.0
+packaging==23.0
     # via
     #   pyproject-api
     #   pytest
     #   python-semantic-release
     #   sphinx
     #   tox
-pkginfo==1.9.2
+pkginfo==1.9.6
     # via twine
-platformdirs==2.6.0
+platformdirs==3.0.0
     # via
     #   tox
     #   virtualenv
@@ -107,25 +109,25 @@ pluggy==1.0.0
     #   tox
 pycparser==2.21
     # via cffi
-pygments==2.13.0
+pygments==2.14.0
     # via
     #   readme-renderer
     #   sphinx
-pyproject-api==1.2.1
+pyproject-api==1.5.0
     # via tox
-pytest==7.2.0
+pytest==7.2.1
     # via -r requirements/dev-requirements.in
-python-gitlab==3.12.0
+python-gitlab==3.13.0
     # via python-semantic-release
-python-semantic-release==7.32.2
+python-semantic-release==7.33.1
     # via -r requirements/dev-requirements.in
-pytz==2022.6
+pytz==2022.7.1
     # via babel
 readme-renderer==37.3
     # via twine
 recommonmark==0.7.1
     # via -r requirements/dev-requirements.in
-requests==2.28.1
+requests==2.28.2
     # via
     #   python-gitlab
     #   python-semantic-release
@@ -153,7 +155,7 @@ sphinx==5.3.0
     #   -r requirements/dev-requirements.in
     #   recommonmark
     #   sphinx-rtd-theme
-sphinx-rtd-theme==1.1.1
+sphinx-rtd-theme==1.2.0
     # via -r requirements/dev-requirements.in
 sphinxcontrib-applehelp==1.0.2
     # via sphinx
@@ -161,6 +163,8 @@ sphinxcontrib-devhelp==1.0.2
     # via sphinx
 sphinxcontrib-htmlhelp==2.0.0
     # via sphinx
+sphinxcontrib-jquery==2.0.0
+    # via sphinx-rtd-theme
 sphinxcontrib-jsmath==1.0.1
     # via sphinx
 sphinxcontrib-qthelp==1.0.3
@@ -174,26 +178,32 @@ tomli==2.0.1
     #   tox
 tomlkit==0.11.6
     # via python-semantic-release
-tox==4.0.10
+tox==4.4.5
     # via -r requirements/dev-requirements.in
 tqdm==4.64.1
     # via twine
 twine==3.8.0
     # via python-semantic-release
-typing-extensions==4.4.0
+typing-extensions==4.5.0
     # via
     #   gitpython
     #   importlib-metadata
+    #   platformdirs
     #   tox
-urllib3==1.26.13
+urllib3==1.26.14
     # via
     #   requests
     #   twine
-virtualenv==20.17.1
+virtualenv==20.19.0
     # via tox
 webencodings==0.5.1
     # via bleach
 wheel==0.38.4
     # via python-semantic-release
-zipp==3.11.0
-    # via importlib-metadata
+zipp==3.13.0
+    # via
+    #   importlib-metadata
+    #   importlib-resources
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools

--- a/requirements/dev-requirements-py38.txt
+++ b/requirements/dev-requirements-py38.txt
@@ -4,15 +4,15 @@
 #
 #    pip-compile --output-file=requirements/dev-requirements-py38.txt requirements/dev-requirements.in
 #
-alabaster==0.7.12
+alabaster==0.7.13
     # via sphinx
-attrs==22.1.0
+attrs==22.2.0
     # via pytest
 babel==2.11.0
     # via sphinx
-bleach==5.0.1
+bleach==6.0.0
     # via readme-renderer
-cachetools==5.2.0
+cachetools==5.3.0
     # via tox
 certifi==2022.12.7
     # via requests
@@ -20,7 +20,7 @@ cffi==1.15.1
     # via cryptography
 chardet==5.1.0
     # via tox
-charset-normalizer==2.1.1
+charset-normalizer==3.0.1
     # via requests
 click==8.1.3
     # via
@@ -34,11 +34,11 @@ colorama==0.4.6
     #   twine
 commonmark==0.9.1
     # via recommonmark
-cryptography==38.0.4
+cryptography==39.0.1
     # via secretstorage
 distlib==0.3.6
     # via virtualenv
-docutils==0.17.1
+docutils==0.18.1
     # via
     #   readme-renderer
     #   recommonmark
@@ -46,26 +46,28 @@ docutils==0.17.1
     #   sphinx-rtd-theme
 dotty-dict==1.3.1
     # via python-semantic-release
-exceptiongroup==1.0.4
+exceptiongroup==1.1.0
     # via pytest
-filelock==3.8.2
+filelock==3.9.0
     # via
     #   tox
     #   virtualenv
 gitdb==4.0.10
     # via gitpython
-gitpython==3.1.29
+gitpython==3.1.30
     # via python-semantic-release
 idna==3.4
     # via requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==5.1.0
+importlib-metadata==6.0.0
     # via
     #   keyring
     #   sphinx
     #   twine
-iniconfig==1.1.1
+importlib-resources==5.10.2
+    # via keyring
+iniconfig==2.0.0
     # via pytest
 invoke==1.7.3
     # via python-semantic-release
@@ -77,22 +79,22 @@ jeepney==0.8.0
     #   secretstorage
 jinja2==3.1.2
     # via sphinx
-keyring==23.11.0
+keyring==23.13.1
     # via twine
-markupsafe==2.1.1
+markupsafe==2.1.2
     # via jinja2
 more-itertools==9.0.0
     # via jaraco-classes
-packaging==22.0
+packaging==23.0
     # via
     #   pyproject-api
     #   pytest
     #   python-semantic-release
     #   sphinx
     #   tox
-pkginfo==1.9.2
+pkginfo==1.9.6
     # via twine
-platformdirs==2.6.0
+platformdirs==3.0.0
     # via
     #   tox
     #   virtualenv
@@ -102,25 +104,25 @@ pluggy==1.0.0
     #   tox
 pycparser==2.21
     # via cffi
-pygments==2.13.0
+pygments==2.14.0
     # via
     #   readme-renderer
     #   sphinx
-pyproject-api==1.2.1
+pyproject-api==1.5.0
     # via tox
-pytest==7.2.0
+pytest==7.2.1
     # via -r requirements/dev-requirements.in
-python-gitlab==3.12.0
+python-gitlab==3.13.0
     # via python-semantic-release
-python-semantic-release==7.32.2
+python-semantic-release==7.33.1
     # via -r requirements/dev-requirements.in
-pytz==2022.6
+pytz==2022.7.1
     # via babel
 readme-renderer==37.3
     # via twine
 recommonmark==0.7.1
     # via -r requirements/dev-requirements.in
-requests==2.28.1
+requests==2.28.2
     # via
     #   python-gitlab
     #   python-semantic-release
@@ -143,19 +145,21 @@ smmap==5.0.0
     # via gitdb
 snowballstemmer==2.2.0
     # via sphinx
-sphinx==5.3.0
+sphinx==6.1.3
     # via
     #   -r requirements/dev-requirements.in
     #   recommonmark
     #   sphinx-rtd-theme
-sphinx-rtd-theme==1.1.1
+sphinx-rtd-theme==1.2.0
     # via -r requirements/dev-requirements.in
-sphinxcontrib-applehelp==1.0.2
+sphinxcontrib-applehelp==1.0.4
     # via sphinx
 sphinxcontrib-devhelp==1.0.2
     # via sphinx
-sphinxcontrib-htmlhelp==2.0.0
+sphinxcontrib-htmlhelp==2.0.1
     # via sphinx
+sphinxcontrib-jquery==2.0.0
+    # via sphinx-rtd-theme
 sphinxcontrib-jsmath==1.0.1
     # via sphinx
 sphinxcontrib-qthelp==1.0.3
@@ -169,21 +173,26 @@ tomli==2.0.1
     #   tox
 tomlkit==0.11.6
     # via python-semantic-release
-tox==4.0.10
+tox==4.4.5
     # via -r requirements/dev-requirements.in
 tqdm==4.64.1
     # via twine
 twine==3.8.0
     # via python-semantic-release
-urllib3==1.26.13
+urllib3==1.26.14
     # via
     #   requests
     #   twine
-virtualenv==20.17.1
+virtualenv==20.19.0
     # via tox
 webencodings==0.5.1
     # via bleach
 wheel==0.38.4
     # via python-semantic-release
-zipp==3.11.0
-    # via importlib-metadata
+zipp==3.13.0
+    # via
+    #   importlib-metadata
+    #   importlib-resources
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools

--- a/requirements/dev-requirements-py39.txt
+++ b/requirements/dev-requirements-py39.txt
@@ -4,15 +4,15 @@
 #
 #    pip-compile --output-file=requirements/dev-requirements-py39.txt requirements/dev-requirements.in
 #
-alabaster==0.7.12
+alabaster==0.7.13
     # via sphinx
-attrs==22.1.0
+attrs==22.2.0
     # via pytest
 babel==2.11.0
     # via sphinx
-bleach==5.0.1
+bleach==6.0.0
     # via readme-renderer
-cachetools==5.2.0
+cachetools==5.3.0
     # via tox
 certifi==2022.12.7
     # via requests
@@ -20,7 +20,7 @@ cffi==1.15.1
     # via cryptography
 chardet==5.1.0
     # via tox
-charset-normalizer==2.1.1
+charset-normalizer==3.0.1
     # via requests
 click==8.1.3
     # via
@@ -34,11 +34,11 @@ colorama==0.4.6
     #   twine
 commonmark==0.9.1
     # via recommonmark
-cryptography==38.0.4
+cryptography==39.0.1
     # via secretstorage
 distlib==0.3.6
     # via virtualenv
-docutils==0.17.1
+docutils==0.18.1
     # via
     #   readme-renderer
     #   recommonmark
@@ -46,26 +46,26 @@ docutils==0.17.1
     #   sphinx-rtd-theme
 dotty-dict==1.3.1
     # via python-semantic-release
-exceptiongroup==1.0.4
+exceptiongroup==1.1.0
     # via pytest
-filelock==3.8.2
+filelock==3.9.0
     # via
     #   tox
     #   virtualenv
 gitdb==4.0.10
     # via gitpython
-gitpython==3.1.29
+gitpython==3.1.30
     # via python-semantic-release
 idna==3.4
     # via requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==5.1.0
+importlib-metadata==6.0.0
     # via
     #   keyring
     #   sphinx
     #   twine
-iniconfig==1.1.1
+iniconfig==2.0.0
     # via pytest
 invoke==1.7.3
     # via python-semantic-release
@@ -77,22 +77,22 @@ jeepney==0.8.0
     #   secretstorage
 jinja2==3.1.2
     # via sphinx
-keyring==23.11.0
+keyring==23.13.1
     # via twine
-markupsafe==2.1.1
+markupsafe==2.1.2
     # via jinja2
 more-itertools==9.0.0
     # via jaraco-classes
-packaging==22.0
+packaging==23.0
     # via
     #   pyproject-api
     #   pytest
     #   python-semantic-release
     #   sphinx
     #   tox
-pkginfo==1.9.2
+pkginfo==1.9.6
     # via twine
-platformdirs==2.6.0
+platformdirs==3.0.0
     # via
     #   tox
     #   virtualenv
@@ -102,25 +102,25 @@ pluggy==1.0.0
     #   tox
 pycparser==2.21
     # via cffi
-pygments==2.13.0
+pygments==2.14.0
     # via
     #   readme-renderer
     #   sphinx
-pyproject-api==1.2.1
+pyproject-api==1.5.0
     # via tox
-pytest==7.2.0
+pytest==7.2.1
     # via -r requirements/dev-requirements.in
-python-gitlab==3.12.0
+python-gitlab==3.13.0
     # via python-semantic-release
-python-semantic-release==7.32.2
+python-semantic-release==7.33.1
     # via -r requirements/dev-requirements.in
-pytz==2022.6
+pytz==2022.7.1
     # via babel
 readme-renderer==37.3
     # via twine
 recommonmark==0.7.1
     # via -r requirements/dev-requirements.in
-requests==2.28.1
+requests==2.28.2
     # via
     #   python-gitlab
     #   python-semantic-release
@@ -143,19 +143,21 @@ smmap==5.0.0
     # via gitdb
 snowballstemmer==2.2.0
     # via sphinx
-sphinx==5.3.0
+sphinx==6.1.3
     # via
     #   -r requirements/dev-requirements.in
     #   recommonmark
     #   sphinx-rtd-theme
-sphinx-rtd-theme==1.1.1
+sphinx-rtd-theme==1.2.0
     # via -r requirements/dev-requirements.in
-sphinxcontrib-applehelp==1.0.2
+sphinxcontrib-applehelp==1.0.4
     # via sphinx
 sphinxcontrib-devhelp==1.0.2
     # via sphinx
-sphinxcontrib-htmlhelp==2.0.0
+sphinxcontrib-htmlhelp==2.0.1
     # via sphinx
+sphinxcontrib-jquery==2.0.0
+    # via sphinx-rtd-theme
 sphinxcontrib-jsmath==1.0.1
     # via sphinx
 sphinxcontrib-qthelp==1.0.3
@@ -169,21 +171,24 @@ tomli==2.0.1
     #   tox
 tomlkit==0.11.6
     # via python-semantic-release
-tox==4.0.10
+tox==4.4.5
     # via -r requirements/dev-requirements.in
 tqdm==4.64.1
     # via twine
 twine==3.8.0
     # via python-semantic-release
-urllib3==1.26.13
+urllib3==1.26.14
     # via
     #   requests
     #   twine
-virtualenv==20.17.1
+virtualenv==20.19.0
     # via tox
 webencodings==0.5.1
     # via bleach
 wheel==0.38.4
     # via python-semantic-release
-zipp==3.11.0
+zipp==3.13.0
     # via importlib-metadata
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools


### PR DESCRIPTION
This PR provides recompiled deps for all outdated       package versions. It was opened after the committed deps       were successfully compiled and all tests passed with the       new versions. It should be merged as soon as possible to       avoid any security issues due to outdated dependencies.