### PR TITLE
Update deps

### DIFF
--- a/requirements/dev-requirements-py310.txt
+++ b/requirements/dev-requirements-py310.txt
@@ -6,21 +6,19 @@
 #
 alabaster==0.7.13
     # via sphinx
-attrs==22.2.0
-    # via pytest
-babel==2.11.0
+babel==2.12.1
     # via sphinx
 bleach==6.0.0
     # via readme-renderer
-cachetools==5.3.0
+cachetools==5.3.1
     # via tox
-certifi==2022.12.7
+certifi==2023.5.7
     # via requests
 cffi==1.15.1
     # via cryptography
 chardet==5.1.0
     # via tox
-charset-normalizer==3.0.1
+charset-normalizer==3.1.0
     # via requests
 click==8.1.3
     # via
@@ -34,7 +32,7 @@ colorama==0.4.6
     #   twine
 commonmark==0.9.1
     # via recommonmark
-cryptography==39.0.1
+cryptography==41.0.1
     # via secretstorage
 distlib==0.3.6
     # via virtualenv
@@ -46,27 +44,27 @@ docutils==0.18.1
     #   sphinx-rtd-theme
 dotty-dict==1.3.1
     # via python-semantic-release
-exceptiongroup==1.1.0
+exceptiongroup==1.1.1
     # via pytest
-filelock==3.9.0
+filelock==3.12.2
     # via
     #   tox
     #   virtualenv
 gitdb==4.0.10
     # via gitpython
-gitpython==3.1.30
+gitpython==3.1.31
     # via python-semantic-release
 idna==3.4
     # via requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==6.0.0
+importlib-metadata==6.7.0
     # via
     #   keyring
     #   twine
 iniconfig==2.0.0
     # via pytest
-invoke==1.7.3
+invoke==2.1.3
     # via python-semantic-release
 jaraco-classes==3.2.3
     # via keyring
@@ -76,13 +74,13 @@ jeepney==0.8.0
     #   secretstorage
 jinja2==3.1.2
     # via sphinx
-keyring==23.13.1
+keyring==24.2.0
     # via twine
-markupsafe==2.1.2
+markupsafe==2.1.3
     # via jinja2
-more-itertools==9.0.0
+more-itertools==9.1.0
     # via jaraco-classes
-packaging==23.0
+packaging==23.1
     # via
     #   pyproject-api
     #   pytest
@@ -91,42 +89,40 @@ packaging==23.0
     #   tox
 pkginfo==1.9.6
     # via twine
-platformdirs==3.0.0
+platformdirs==3.8.0
     # via
     #   tox
     #   virtualenv
-pluggy==1.0.0
+pluggy==1.2.0
     # via
     #   pytest
     #   tox
 pycparser==2.21
     # via cffi
-pygments==2.14.0
+pygments==2.15.1
     # via
     #   readme-renderer
     #   sphinx
-pyproject-api==1.5.0
+pyproject-api==1.5.2
     # via tox
-pytest==7.2.1
+pytest==7.4.0
     # via -r requirements/dev-requirements.in
-python-gitlab==3.13.0
+python-gitlab==3.15.0
     # via python-semantic-release
-python-semantic-release==7.33.1
+python-semantic-release==7.34.6
     # via -r requirements/dev-requirements.in
-pytz==2022.7.1
-    # via babel
-readme-renderer==37.3
+readme-renderer==40.0
     # via twine
 recommonmark==0.7.1
     # via -r requirements/dev-requirements.in
-requests==2.28.2
+requests==2.31.0
     # via
     #   python-gitlab
     #   python-semantic-release
     #   requests-toolbelt
     #   sphinx
     #   twine
-requests-toolbelt==0.10.1
+requests-toolbelt==1.0.0
     # via
     #   python-gitlab
     #   twine
@@ -142,12 +138,13 @@ smmap==5.0.0
     # via gitdb
 snowballstemmer==2.2.0
     # via sphinx
-sphinx==6.1.3
+sphinx==6.2.1
     # via
     #   -r requirements/dev-requirements.in
     #   recommonmark
     #   sphinx-rtd-theme
-sphinx-rtd-theme==1.2.0
+    #   sphinxcontrib-jquery
+sphinx-rtd-theme==1.2.2
     # via -r requirements/dev-requirements.in
 sphinxcontrib-applehelp==1.0.4
     # via sphinx
@@ -155,7 +152,7 @@ sphinxcontrib-devhelp==1.0.2
     # via sphinx
 sphinxcontrib-htmlhelp==2.0.1
     # via sphinx
-sphinxcontrib-jquery==2.0.0
+sphinxcontrib-jquery==4.1
     # via sphinx-rtd-theme
 sphinxcontrib-jsmath==1.0.1
     # via sphinx
@@ -168,26 +165,23 @@ tomli==2.0.1
     #   pyproject-api
     #   pytest
     #   tox
-tomlkit==0.11.6
+tomlkit==0.11.8
     # via python-semantic-release
-tox==4.4.5
+tox==4.6.3
     # via -r requirements/dev-requirements.in
-tqdm==4.64.1
+tqdm==4.65.0
     # via twine
 twine==3.8.0
     # via python-semantic-release
-urllib3==1.26.14
+urllib3==2.0.3
     # via
     #   requests
     #   twine
-virtualenv==20.19.0
+virtualenv==20.23.1
     # via tox
 webencodings==0.5.1
     # via bleach
-wheel==0.38.4
+wheel==0.40.0
     # via python-semantic-release
-zipp==3.13.0
+zipp==3.15.0
     # via importlib-metadata
-
-# The following packages are considered to be unsafe in a requirements file:
-# setuptools

--- a/requirements/dev-requirements-py37.txt
+++ b/requirements/dev-requirements-py37.txt
@@ -6,21 +6,19 @@
 #
 alabaster==0.7.13
     # via sphinx
-attrs==22.2.0
-    # via pytest
-babel==2.11.0
+babel==2.12.1
     # via sphinx
 bleach==6.0.0
     # via readme-renderer
-cachetools==5.3.0
+cachetools==5.3.1
     # via tox
-certifi==2022.12.7
+certifi==2023.5.7
     # via requests
 cffi==1.15.1
     # via cryptography
 chardet==5.1.0
     # via tox
-charset-normalizer==3.0.1
+charset-normalizer==3.1.0
     # via requests
 click==8.1.3
     # via
@@ -34,7 +32,7 @@ colorama==0.4.6
     #   twine
 commonmark==0.9.1
     # via recommonmark
-cryptography==39.0.1
+cryptography==41.0.1
     # via secretstorage
 distlib==0.3.6
     # via virtualenv
@@ -46,21 +44,21 @@ docutils==0.18.1
     #   sphinx-rtd-theme
 dotty-dict==1.3.1
     # via python-semantic-release
-exceptiongroup==1.1.0
+exceptiongroup==1.1.1
     # via pytest
-filelock==3.9.0
+filelock==3.12.2
     # via
     #   tox
     #   virtualenv
 gitdb==4.0.10
     # via gitpython
-gitpython==3.1.30
+gitpython==3.1.31
     # via python-semantic-release
 idna==3.4
     # via requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==6.0.0
+importlib-metadata==6.7.0
     # via
     #   click
     #   keyring
@@ -70,11 +68,11 @@ importlib-metadata==6.0.0
     #   tox
     #   twine
     #   virtualenv
-importlib-resources==5.10.2
+importlib-resources==5.12.0
     # via keyring
 iniconfig==2.0.0
     # via pytest
-invoke==1.7.3
+invoke==2.1.3
     # via python-semantic-release
 jaraco-classes==3.2.3
     # via keyring
@@ -84,13 +82,13 @@ jeepney==0.8.0
     #   secretstorage
 jinja2==3.1.2
     # via sphinx
-keyring==23.13.1
+keyring==24.1.1
     # via twine
-markupsafe==2.1.2
+markupsafe==2.1.3
     # via jinja2
-more-itertools==9.0.0
+more-itertools==9.1.0
     # via jaraco-classes
-packaging==23.0
+packaging==23.1
     # via
     #   pyproject-api
     #   pytest
@@ -99,42 +97,42 @@ packaging==23.0
     #   tox
 pkginfo==1.9.6
     # via twine
-platformdirs==3.0.0
+platformdirs==3.8.0
     # via
     #   tox
     #   virtualenv
-pluggy==1.0.0
+pluggy==1.2.0
     # via
     #   pytest
     #   tox
 pycparser==2.21
     # via cffi
-pygments==2.14.0
+pygments==2.15.1
     # via
     #   readme-renderer
     #   sphinx
-pyproject-api==1.5.0
+pyproject-api==1.5.2
     # via tox
-pytest==7.2.1
+pytest==7.4.0
     # via -r requirements/dev-requirements.in
-python-gitlab==3.13.0
+python-gitlab==3.15.0
     # via python-semantic-release
-python-semantic-release==7.33.1
+python-semantic-release==7.34.6
     # via -r requirements/dev-requirements.in
-pytz==2022.7.1
+pytz==2023.3
     # via babel
 readme-renderer==37.3
     # via twine
 recommonmark==0.7.1
     # via -r requirements/dev-requirements.in
-requests==2.28.2
+requests==2.31.0
     # via
     #   python-gitlab
     #   python-semantic-release
     #   requests-toolbelt
     #   sphinx
     #   twine
-requests-toolbelt==0.10.1
+requests-toolbelt==1.0.0
     # via
     #   python-gitlab
     #   twine
@@ -155,7 +153,8 @@ sphinx==5.3.0
     #   -r requirements/dev-requirements.in
     #   recommonmark
     #   sphinx-rtd-theme
-sphinx-rtd-theme==1.2.0
+    #   sphinxcontrib-jquery
+sphinx-rtd-theme==1.2.2
     # via -r requirements/dev-requirements.in
 sphinxcontrib-applehelp==1.0.2
     # via sphinx
@@ -163,7 +162,7 @@ sphinxcontrib-devhelp==1.0.2
     # via sphinx
 sphinxcontrib-htmlhelp==2.0.0
     # via sphinx
-sphinxcontrib-jquery==2.0.0
+sphinxcontrib-jquery==4.1
     # via sphinx-rtd-theme
 sphinxcontrib-jsmath==1.0.1
     # via sphinx
@@ -176,34 +175,32 @@ tomli==2.0.1
     #   pyproject-api
     #   pytest
     #   tox
-tomlkit==0.11.6
+tomlkit==0.11.8
     # via python-semantic-release
-tox==4.4.5
+tox==4.6.3
     # via -r requirements/dev-requirements.in
-tqdm==4.64.1
+tqdm==4.65.0
     # via twine
 twine==3.8.0
     # via python-semantic-release
-typing-extensions==4.5.0
+typing-extensions==4.7.0
     # via
     #   gitpython
     #   importlib-metadata
     #   platformdirs
+    #   python-gitlab
     #   tox
-urllib3==1.26.14
+urllib3==2.0.3
     # via
     #   requests
     #   twine
-virtualenv==20.19.0
+virtualenv==20.23.1
     # via tox
 webencodings==0.5.1
     # via bleach
-wheel==0.38.4
+wheel==0.40.0
     # via python-semantic-release
-zipp==3.13.0
+zipp==3.15.0
     # via
     #   importlib-metadata
     #   importlib-resources
-
-# The following packages are considered to be unsafe in a requirements file:
-# setuptools

--- a/requirements/dev-requirements-py38.txt
+++ b/requirements/dev-requirements-py38.txt
@@ -6,21 +6,19 @@
 #
 alabaster==0.7.13
     # via sphinx
-attrs==22.2.0
-    # via pytest
-babel==2.11.0
+babel==2.12.1
     # via sphinx
 bleach==6.0.0
     # via readme-renderer
-cachetools==5.3.0
+cachetools==5.3.1
     # via tox
-certifi==2022.12.7
+certifi==2023.5.7
     # via requests
 cffi==1.15.1
     # via cryptography
 chardet==5.1.0
     # via tox
-charset-normalizer==3.0.1
+charset-normalizer==3.1.0
     # via requests
 click==8.1.3
     # via
@@ -34,7 +32,7 @@ colorama==0.4.6
     #   twine
 commonmark==0.9.1
     # via recommonmark
-cryptography==39.0.1
+cryptography==41.0.1
     # via secretstorage
 distlib==0.3.6
     # via virtualenv
@@ -46,30 +44,30 @@ docutils==0.18.1
     #   sphinx-rtd-theme
 dotty-dict==1.3.1
     # via python-semantic-release
-exceptiongroup==1.1.0
+exceptiongroup==1.1.1
     # via pytest
-filelock==3.9.0
+filelock==3.12.2
     # via
     #   tox
     #   virtualenv
 gitdb==4.0.10
     # via gitpython
-gitpython==3.1.30
+gitpython==3.1.31
     # via python-semantic-release
 idna==3.4
     # via requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==6.0.0
+importlib-metadata==6.7.0
     # via
     #   keyring
     #   sphinx
     #   twine
-importlib-resources==5.10.2
+importlib-resources==5.12.0
     # via keyring
 iniconfig==2.0.0
     # via pytest
-invoke==1.7.3
+invoke==2.1.3
     # via python-semantic-release
 jaraco-classes==3.2.3
     # via keyring
@@ -79,13 +77,13 @@ jeepney==0.8.0
     #   secretstorage
 jinja2==3.1.2
     # via sphinx
-keyring==23.13.1
+keyring==24.2.0
     # via twine
-markupsafe==2.1.2
+markupsafe==2.1.3
     # via jinja2
-more-itertools==9.0.0
+more-itertools==9.1.0
     # via jaraco-classes
-packaging==23.0
+packaging==23.1
     # via
     #   pyproject-api
     #   pytest
@@ -94,42 +92,42 @@ packaging==23.0
     #   tox
 pkginfo==1.9.6
     # via twine
-platformdirs==3.0.0
+platformdirs==3.8.0
     # via
     #   tox
     #   virtualenv
-pluggy==1.0.0
+pluggy==1.2.0
     # via
     #   pytest
     #   tox
 pycparser==2.21
     # via cffi
-pygments==2.14.0
+pygments==2.15.1
     # via
     #   readme-renderer
     #   sphinx
-pyproject-api==1.5.0
+pyproject-api==1.5.2
     # via tox
-pytest==7.2.1
+pytest==7.4.0
     # via -r requirements/dev-requirements.in
-python-gitlab==3.13.0
+python-gitlab==3.15.0
     # via python-semantic-release
-python-semantic-release==7.33.1
+python-semantic-release==7.34.6
     # via -r requirements/dev-requirements.in
-pytz==2022.7.1
+pytz==2023.3
     # via babel
-readme-renderer==37.3
+readme-renderer==40.0
     # via twine
 recommonmark==0.7.1
     # via -r requirements/dev-requirements.in
-requests==2.28.2
+requests==2.31.0
     # via
     #   python-gitlab
     #   python-semantic-release
     #   requests-toolbelt
     #   sphinx
     #   twine
-requests-toolbelt==0.10.1
+requests-toolbelt==1.0.0
     # via
     #   python-gitlab
     #   twine
@@ -145,12 +143,13 @@ smmap==5.0.0
     # via gitdb
 snowballstemmer==2.2.0
     # via sphinx
-sphinx==6.1.3
+sphinx==6.2.1
     # via
     #   -r requirements/dev-requirements.in
     #   recommonmark
     #   sphinx-rtd-theme
-sphinx-rtd-theme==1.2.0
+    #   sphinxcontrib-jquery
+sphinx-rtd-theme==1.2.2
     # via -r requirements/dev-requirements.in
 sphinxcontrib-applehelp==1.0.4
     # via sphinx
@@ -158,7 +157,7 @@ sphinxcontrib-devhelp==1.0.2
     # via sphinx
 sphinxcontrib-htmlhelp==2.0.1
     # via sphinx
-sphinxcontrib-jquery==2.0.0
+sphinxcontrib-jquery==4.1
     # via sphinx-rtd-theme
 sphinxcontrib-jsmath==1.0.1
     # via sphinx
@@ -171,28 +170,25 @@ tomli==2.0.1
     #   pyproject-api
     #   pytest
     #   tox
-tomlkit==0.11.6
+tomlkit==0.11.8
     # via python-semantic-release
-tox==4.4.5
+tox==4.6.3
     # via -r requirements/dev-requirements.in
-tqdm==4.64.1
+tqdm==4.65.0
     # via twine
 twine==3.8.0
     # via python-semantic-release
-urllib3==1.26.14
+urllib3==2.0.3
     # via
     #   requests
     #   twine
-virtualenv==20.19.0
+virtualenv==20.23.1
     # via tox
 webencodings==0.5.1
     # via bleach
-wheel==0.38.4
+wheel==0.40.0
     # via python-semantic-release
-zipp==3.13.0
+zipp==3.15.0
     # via
     #   importlib-metadata
     #   importlib-resources
-
-# The following packages are considered to be unsafe in a requirements file:
-# setuptools

--- a/requirements/dev-requirements-py39.txt
+++ b/requirements/dev-requirements-py39.txt
@@ -6,21 +6,19 @@
 #
 alabaster==0.7.13
     # via sphinx
-attrs==22.2.0
-    # via pytest
-babel==2.11.0
+babel==2.12.1
     # via sphinx
 bleach==6.0.0
     # via readme-renderer
-cachetools==5.3.0
+cachetools==5.3.1
     # via tox
-certifi==2022.12.7
+certifi==2023.5.7
     # via requests
 cffi==1.15.1
     # via cryptography
 chardet==5.1.0
     # via tox
-charset-normalizer==3.0.1
+charset-normalizer==3.1.0
     # via requests
 click==8.1.3
     # via
@@ -34,7 +32,7 @@ colorama==0.4.6
     #   twine
 commonmark==0.9.1
     # via recommonmark
-cryptography==39.0.1
+cryptography==41.0.1
     # via secretstorage
 distlib==0.3.6
     # via virtualenv
@@ -46,28 +44,28 @@ docutils==0.18.1
     #   sphinx-rtd-theme
 dotty-dict==1.3.1
     # via python-semantic-release
-exceptiongroup==1.1.0
+exceptiongroup==1.1.1
     # via pytest
-filelock==3.9.0
+filelock==3.12.2
     # via
     #   tox
     #   virtualenv
 gitdb==4.0.10
     # via gitpython
-gitpython==3.1.30
+gitpython==3.1.31
     # via python-semantic-release
 idna==3.4
     # via requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==6.0.0
+importlib-metadata==6.7.0
     # via
     #   keyring
     #   sphinx
     #   twine
 iniconfig==2.0.0
     # via pytest
-invoke==1.7.3
+invoke==2.1.3
     # via python-semantic-release
 jaraco-classes==3.2.3
     # via keyring
@@ -77,13 +75,13 @@ jeepney==0.8.0
     #   secretstorage
 jinja2==3.1.2
     # via sphinx
-keyring==23.13.1
+keyring==24.2.0
     # via twine
-markupsafe==2.1.2
+markupsafe==2.1.3
     # via jinja2
-more-itertools==9.0.0
+more-itertools==9.1.0
     # via jaraco-classes
-packaging==23.0
+packaging==23.1
     # via
     #   pyproject-api
     #   pytest
@@ -92,42 +90,40 @@ packaging==23.0
     #   tox
 pkginfo==1.9.6
     # via twine
-platformdirs==3.0.0
+platformdirs==3.8.0
     # via
     #   tox
     #   virtualenv
-pluggy==1.0.0
+pluggy==1.2.0
     # via
     #   pytest
     #   tox
 pycparser==2.21
     # via cffi
-pygments==2.14.0
+pygments==2.15.1
     # via
     #   readme-renderer
     #   sphinx
-pyproject-api==1.5.0
+pyproject-api==1.5.2
     # via tox
-pytest==7.2.1
+pytest==7.4.0
     # via -r requirements/dev-requirements.in
-python-gitlab==3.13.0
+python-gitlab==3.15.0
     # via python-semantic-release
-python-semantic-release==7.33.1
+python-semantic-release==7.34.6
     # via -r requirements/dev-requirements.in
-pytz==2022.7.1
-    # via babel
-readme-renderer==37.3
+readme-renderer==40.0
     # via twine
 recommonmark==0.7.1
     # via -r requirements/dev-requirements.in
-requests==2.28.2
+requests==2.31.0
     # via
     #   python-gitlab
     #   python-semantic-release
     #   requests-toolbelt
     #   sphinx
     #   twine
-requests-toolbelt==0.10.1
+requests-toolbelt==1.0.0
     # via
     #   python-gitlab
     #   twine
@@ -143,12 +139,13 @@ smmap==5.0.0
     # via gitdb
 snowballstemmer==2.2.0
     # via sphinx
-sphinx==6.1.3
+sphinx==6.2.1
     # via
     #   -r requirements/dev-requirements.in
     #   recommonmark
     #   sphinx-rtd-theme
-sphinx-rtd-theme==1.2.0
+    #   sphinxcontrib-jquery
+sphinx-rtd-theme==1.2.2
     # via -r requirements/dev-requirements.in
 sphinxcontrib-applehelp==1.0.4
     # via sphinx
@@ -156,7 +153,7 @@ sphinxcontrib-devhelp==1.0.2
     # via sphinx
 sphinxcontrib-htmlhelp==2.0.1
     # via sphinx
-sphinxcontrib-jquery==2.0.0
+sphinxcontrib-jquery==4.1
     # via sphinx-rtd-theme
 sphinxcontrib-jsmath==1.0.1
     # via sphinx
@@ -169,26 +166,23 @@ tomli==2.0.1
     #   pyproject-api
     #   pytest
     #   tox
-tomlkit==0.11.6
+tomlkit==0.11.8
     # via python-semantic-release
-tox==4.4.5
+tox==4.6.3
     # via -r requirements/dev-requirements.in
-tqdm==4.64.1
+tqdm==4.65.0
     # via twine
 twine==3.8.0
     # via python-semantic-release
-urllib3==1.26.14
+urllib3==2.0.3
     # via
     #   requests
     #   twine
-virtualenv==20.19.0
+virtualenv==20.23.1
     # via tox
 webencodings==0.5.1
     # via bleach
-wheel==0.38.4
+wheel==0.40.0
     # via python-semantic-release
-zipp==3.13.0
+zipp==3.15.0
     # via importlib-metadata
-
-# The following packages are considered to be unsafe in a requirements file:
-# setuptools


### PR DESCRIPTION
This PR provides recompiled deps for all outdated       package versions. It was opened after the committed deps       were successfully compiled and all tests passed with the       new versions. It should be merged as soon as possible to       avoid any security issues due to outdated dependencies.