### PR TITLE
Update deps

### DIFF
--- a/requirements/dev-requirements-py310.txt
+++ b/requirements/dev-requirements-py310.txt
@@ -18,9 +18,9 @@ cffi==1.15.1
     # via cryptography
 chardet==5.1.0
     # via tox
-charset-normalizer==3.1.0
+charset-normalizer==3.2.0
     # via requests
-click==8.1.3
+click==8.1.5
     # via
     #   click-log
     #   python-semantic-release
@@ -32,7 +32,7 @@ colorama==0.4.6
     #   twine
 commonmark==0.9.1
     # via recommonmark
-cryptography==41.0.1
+cryptography==41.0.2
     # via secretstorage
 distlib==0.3.6
     # via virtualenv
@@ -44,7 +44,7 @@ docutils==0.18.1
     #   sphinx-rtd-theme
 dotty-dict==1.3.1
     # via python-semantic-release
-exceptiongroup==1.1.1
+exceptiongroup==1.1.2
     # via pytest
 filelock==3.12.2
     # via
@@ -52,21 +52,21 @@ filelock==3.12.2
     #   virtualenv
 gitdb==4.0.10
     # via gitpython
-gitpython==3.1.31
+gitpython==3.1.32
     # via python-semantic-release
 idna==3.4
     # via requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==6.7.0
+importlib-metadata==6.8.0
     # via
     #   keyring
     #   twine
 iniconfig==2.0.0
     # via pytest
-invoke==2.1.3
+invoke==2.2.0
     # via python-semantic-release
-jaraco-classes==3.2.3
+jaraco-classes==3.3.0
     # via keyring
 jeepney==0.8.0
     # via
@@ -89,7 +89,7 @@ packaging==23.1
     #   tox
 pkginfo==1.9.6
     # via twine
-platformdirs==3.8.0
+platformdirs==3.8.1
     # via
     #   tox
     #   virtualenv
@@ -103,7 +103,7 @@ pygments==2.15.1
     # via
     #   readme-renderer
     #   sphinx
-pyproject-api==1.5.2
+pyproject-api==1.5.3
     # via tox
 pytest==7.4.0
     # via -r requirements/dev-requirements.in
@@ -167,7 +167,7 @@ tomli==2.0.1
     #   tox
 tomlkit==0.11.8
     # via python-semantic-release
-tox==4.6.3
+tox==4.6.4
     # via -r requirements/dev-requirements.in
 tqdm==4.65.0
     # via twine
@@ -177,11 +177,11 @@ urllib3==2.0.3
     # via
     #   requests
     #   twine
-virtualenv==20.23.1
+virtualenv==20.24.0
     # via tox
 webencodings==0.5.1
     # via bleach
 wheel==0.40.0
     # via python-semantic-release
-zipp==3.15.0
+zipp==3.16.2
     # via importlib-metadata

--- a/requirements/dev-requirements-py37.txt
+++ b/requirements/dev-requirements-py37.txt
@@ -18,9 +18,9 @@ cffi==1.15.1
     # via cryptography
 chardet==5.1.0
     # via tox
-charset-normalizer==3.1.0
+charset-normalizer==3.2.0
     # via requests
-click==8.1.3
+click==8.1.5
     # via
     #   click-log
     #   python-semantic-release
@@ -32,7 +32,7 @@ colorama==0.4.6
     #   twine
 commonmark==0.9.1
     # via recommonmark
-cryptography==41.0.1
+cryptography==41.0.2
     # via secretstorage
 distlib==0.3.6
     # via virtualenv
@@ -44,7 +44,7 @@ docutils==0.18.1
     #   sphinx-rtd-theme
 dotty-dict==1.3.1
     # via python-semantic-release
-exceptiongroup==1.1.1
+exceptiongroup==1.1.2
     # via pytest
 filelock==3.12.2
     # via
@@ -52,7 +52,7 @@ filelock==3.12.2
     #   virtualenv
 gitdb==4.0.10
     # via gitpython
-gitpython==3.1.31
+gitpython==3.1.32
     # via python-semantic-release
 idna==3.4
     # via requests
@@ -72,7 +72,7 @@ importlib-resources==5.12.0
     # via keyring
 iniconfig==2.0.0
     # via pytest
-invoke==2.1.3
+invoke==2.2.0
     # via python-semantic-release
 jaraco-classes==3.2.3
     # via keyring
@@ -97,7 +97,7 @@ packaging==23.1
     #   tox
 pkginfo==1.9.6
     # via twine
-platformdirs==3.8.0
+platformdirs==3.8.1
     # via
     #   tox
     #   virtualenv
@@ -111,7 +111,7 @@ pygments==2.15.1
     # via
     #   readme-renderer
     #   sphinx
-pyproject-api==1.5.2
+pyproject-api==1.5.3
     # via tox
 pytest==7.4.0
     # via -r requirements/dev-requirements.in
@@ -177,13 +177,13 @@ tomli==2.0.1
     #   tox
 tomlkit==0.11.8
     # via python-semantic-release
-tox==4.6.3
+tox==4.6.4
     # via -r requirements/dev-requirements.in
 tqdm==4.65.0
     # via twine
 twine==3.8.0
     # via python-semantic-release
-typing-extensions==4.7.0
+typing-extensions==4.7.1
     # via
     #   gitpython
     #   importlib-metadata
@@ -194,7 +194,7 @@ urllib3==2.0.3
     # via
     #   requests
     #   twine
-virtualenv==20.23.1
+virtualenv==20.24.0
     # via tox
 webencodings==0.5.1
     # via bleach

--- a/requirements/dev-requirements-py38.txt
+++ b/requirements/dev-requirements-py38.txt
@@ -18,9 +18,9 @@ cffi==1.15.1
     # via cryptography
 chardet==5.1.0
     # via tox
-charset-normalizer==3.1.0
+charset-normalizer==3.2.0
     # via requests
-click==8.1.3
+click==8.1.5
     # via
     #   click-log
     #   python-semantic-release
@@ -32,7 +32,7 @@ colorama==0.4.6
     #   twine
 commonmark==0.9.1
     # via recommonmark
-cryptography==41.0.1
+cryptography==41.0.2
     # via secretstorage
 distlib==0.3.6
     # via virtualenv
@@ -44,7 +44,7 @@ docutils==0.18.1
     #   sphinx-rtd-theme
 dotty-dict==1.3.1
     # via python-semantic-release
-exceptiongroup==1.1.1
+exceptiongroup==1.1.2
     # via pytest
 filelock==3.12.2
     # via
@@ -52,24 +52,24 @@ filelock==3.12.2
     #   virtualenv
 gitdb==4.0.10
     # via gitpython
-gitpython==3.1.31
+gitpython==3.1.32
     # via python-semantic-release
 idna==3.4
     # via requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==6.7.0
+importlib-metadata==6.8.0
     # via
     #   keyring
     #   sphinx
     #   twine
-importlib-resources==5.12.0
+importlib-resources==6.0.0
     # via keyring
 iniconfig==2.0.0
     # via pytest
-invoke==2.1.3
+invoke==2.2.0
     # via python-semantic-release
-jaraco-classes==3.2.3
+jaraco-classes==3.3.0
     # via keyring
 jeepney==0.8.0
     # via
@@ -92,7 +92,7 @@ packaging==23.1
     #   tox
 pkginfo==1.9.6
     # via twine
-platformdirs==3.8.0
+platformdirs==3.8.1
     # via
     #   tox
     #   virtualenv
@@ -106,7 +106,7 @@ pygments==2.15.1
     # via
     #   readme-renderer
     #   sphinx
-pyproject-api==1.5.2
+pyproject-api==1.5.3
     # via tox
 pytest==7.4.0
     # via -r requirements/dev-requirements.in
@@ -172,7 +172,7 @@ tomli==2.0.1
     #   tox
 tomlkit==0.11.8
     # via python-semantic-release
-tox==4.6.3
+tox==4.6.4
     # via -r requirements/dev-requirements.in
 tqdm==4.65.0
     # via twine
@@ -182,13 +182,13 @@ urllib3==2.0.3
     # via
     #   requests
     #   twine
-virtualenv==20.23.1
+virtualenv==20.24.0
     # via tox
 webencodings==0.5.1
     # via bleach
 wheel==0.40.0
     # via python-semantic-release
-zipp==3.15.0
+zipp==3.16.2
     # via
     #   importlib-metadata
     #   importlib-resources

--- a/requirements/dev-requirements-py39.txt
+++ b/requirements/dev-requirements-py39.txt
@@ -18,9 +18,9 @@ cffi==1.15.1
     # via cryptography
 chardet==5.1.0
     # via tox
-charset-normalizer==3.1.0
+charset-normalizer==3.2.0
     # via requests
-click==8.1.3
+click==8.1.5
     # via
     #   click-log
     #   python-semantic-release
@@ -32,7 +32,7 @@ colorama==0.4.6
     #   twine
 commonmark==0.9.1
     # via recommonmark
-cryptography==41.0.1
+cryptography==41.0.2
     # via secretstorage
 distlib==0.3.6
     # via virtualenv
@@ -44,7 +44,7 @@ docutils==0.18.1
     #   sphinx-rtd-theme
 dotty-dict==1.3.1
     # via python-semantic-release
-exceptiongroup==1.1.1
+exceptiongroup==1.1.2
     # via pytest
 filelock==3.12.2
     # via
@@ -52,22 +52,22 @@ filelock==3.12.2
     #   virtualenv
 gitdb==4.0.10
     # via gitpython
-gitpython==3.1.31
+gitpython==3.1.32
     # via python-semantic-release
 idna==3.4
     # via requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==6.7.0
+importlib-metadata==6.8.0
     # via
     #   keyring
     #   sphinx
     #   twine
 iniconfig==2.0.0
     # via pytest
-invoke==2.1.3
+invoke==2.2.0
     # via python-semantic-release
-jaraco-classes==3.2.3
+jaraco-classes==3.3.0
     # via keyring
 jeepney==0.8.0
     # via
@@ -90,7 +90,7 @@ packaging==23.1
     #   tox
 pkginfo==1.9.6
     # via twine
-platformdirs==3.8.0
+platformdirs==3.8.1
     # via
     #   tox
     #   virtualenv
@@ -104,7 +104,7 @@ pygments==2.15.1
     # via
     #   readme-renderer
     #   sphinx
-pyproject-api==1.5.2
+pyproject-api==1.5.3
     # via tox
 pytest==7.4.0
     # via -r requirements/dev-requirements.in
@@ -168,7 +168,7 @@ tomli==2.0.1
     #   tox
 tomlkit==0.11.8
     # via python-semantic-release
-tox==4.6.3
+tox==4.6.4
     # via -r requirements/dev-requirements.in
 tqdm==4.65.0
     # via twine
@@ -178,11 +178,11 @@ urllib3==2.0.3
     # via
     #   requests
     #   twine
-virtualenv==20.23.1
+virtualenv==20.24.0
     # via tox
 webencodings==0.5.1
     # via bleach
 wheel==0.40.0
     # via python-semantic-release
-zipp==3.15.0
+zipp==3.16.2
     # via importlib-metadata


### PR DESCRIPTION
This PR provides recompiled deps for all outdated       package versions. It was opened after the committed deps       were successfully compiled and all tests passed with the       new versions. It should be merged as soon as possible to       avoid any security issues due to outdated dependencies.